### PR TITLE
chore: code quality tooling (analyzers, Husky, Dependabot, CodeQL)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: /src
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /src/Anichron.API
+    schedule:
+      interval: weekly
+      day: monday
+
+  - package-ecosystem: docker
+    directory: /src/Anichron.Worker
+    schedule:
+      interval: weekly
+      day: monday
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: dotnet build src/
 
       - name: Test
-        run: dotnet test src/ --no-build
+        run: dotnet test src/ --no-build --collect:"XPlat Code Coverage"
 
       - name: Check formatting
         run: dotnet format --verify-no-changes src/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (C#)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build
+        run: dotnet build src/
+
+      - uses: github/codeql-action/analyze@v3

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## husky task runner examples -------------------
+## Note : for local installation use 'dotnet' prefix. e.g. 'dotnet husky'
+
+## run all tasks
+#husky run
+
+### run all tasks with group: 'group-name'
+#husky run --group group-name
+
+## run task with name: 'task-name'
+#husky run --name task-name
+
+## pass hook arguments to task
+#husky run --args "$1" "$2"
+
+## or put your custom commands -------------------
+#echo 'Husky.Net is awesome!'
+
+dotnet husky run --group pre-commit

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
+  "tasks": [
+    {
+      "name": "format-check",
+      "group": "pre-commit",
+      "command": "dotnet",
+      "args": ["format", "--verify-no-changes", "src/"]
+    },
+    {
+      "name": "build",
+      "group": "pre-commit",
+      "command": "dotnet",
+      "args": ["build", "src/", "--no-incremental", "-v", "q"]
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## First-time setup
+
+```bash
+# Install local tools (Husky) and wire up the pre-commit hook
+dotnet tool restore
+dotnet husky install
+```
+
 ## Build & Run
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Multiple users can share the same NAS paths (shared family library). Each user h
 
 - Worker Dockerfile targets `mcr.microsoft.com/dotnet/runtime:10.0-noble` (not Alpine) specifically for FFmpeg + Intel QuickSync GPU support
 - API Dockerfile uses Alpine (no GPU/FFmpeg needed)
-- CI/CD runs on GitHub Actions (`.github/workflows/ci.yml`); API and Worker images built in parallel, tagged with `0.0.<run_number>` (and `latest` on master)
+- CI/CD runs on GitHub Actions (`.github/workflows/ci.yml`); API and Worker images built in parallel; tagged `sha-<hash>` on every build, `edge` on master, SemVer tags on releases
 - PostgreSQL connection is never hardcoded — always read from `POSTGRES_CONNECTION__*` env vars or Docker secrets
 
 ## Development Roadmap

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.9.1",
+      "commands": [
+        "husky"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -283,6 +283,12 @@ dotnet_diagnostic.IDE0058.severity = none
 dotnet_diagnostic.IDE0061.severity = none
 dotnet_diagnostic.IDE0290.severity = suggestion
 dotnet_diagnostic.IDE0305.severity = suggestion
+# RCS1181: Comments that act as section dividers (e.g. "// Navigation Properties") are intentional
+dotnet_diagnostic.RCS1181.severity = none
+# RCS1201: EF Core fluent config benefits from separate statements over method chaining
+dotnet_diagnostic.RCS1201.severity = none
+# VSTHRD111: ConfigureAwait(false) is only needed in library code, not in application services
+dotnet_diagnostic.VSTHRD111.severity = none
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
 dotnet_diagnostic.CA1711.severity = silent

--- a/src/Anichron.API/Program.cs
+++ b/src/Anichron.API/Program.cs
@@ -29,4 +29,4 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-app.Run();
+await app.RunAsync();

--- a/src/Anichron.Infrastructure/Configuration/DatabaseConfiguration.cs
+++ b/src/Anichron.Infrastructure/Configuration/DatabaseConfiguration.cs
@@ -5,7 +5,7 @@ namespace Anichron.Infrastructure.Configuration;
 
 public static class DatabaseConfiguration
 {
-    private static readonly int DefaultPort = 5432;
+    private const int DefaultPort = 5432;
 
     public static string GetConnectionString(IConfiguration configuration)
     {

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -14,28 +14,45 @@
     <ArtifactsPath>$(RepositoryRootDirectory).artifacts</ArtifactsPath>
   </PropertyGroup>
   
-   <PropertyGroup Condition="'$(OptOutAnalyzers)' != 'True'">
+  <PropertyGroup Condition="'$(OptOutAnalyzers)' != 'True'">
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-	<AnalysisMode>Recommended</AnalysisMode>
+    <AnalysisMode>Recommended</AnalysisMode>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="NuGet vulnerability audit">
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditLevel>moderate</NuGetAuditLevel>
+    <NuGetAuditMode>all</NuGetAuditMode>
   </PropertyGroup>
   
   <PropertyGroup Label="Project Properties Evaluation">
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.Tests.Unit'))">True</IsTestProject>
   </PropertyGroup>
   
+  <ItemGroup>
+    <PackageReference Include="Roslynator.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(IsTestProject)' == 'True'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
-	<PackageReference Include="xunit.runner.visualstudio">
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(IsTestProject)' != 'True'">
     <InternalsVisibleTo Include="$(MSBuildProjectName).Tests.Unit" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Label="Production dependencies">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.4" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.4" />
@@ -12,5 +12,14 @@
     <PackageVersion Include="Npgsql" Version="10.0.2" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NodaTime" Version="10.0.1" />
+  </ItemGroup>
+  <ItemGroup Label="Analyzers">
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.25.0.139117" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15" />
+  </ItemGroup>
+  <ItemGroup Label="Test utilities">
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- **Roslynator + SonarAnalyzer + VSTHRD** — three analyzer packages added globally; surface code quality, security, and async/await issues at build time (zero warnings, `TreatWarningsAsErrors` still holds)
- **FluentAssertions + coverlet** — wired into all `*.Tests.Unit` projects automatically; coverage data collected on every CI test run
- **NuGet vulnerability audit** — `NuGetAudit=true` at `moderate` level; `dotnet restore` now fails on known CVEs
- **dotnet-husky** — pre-commit hook runs `dotnet format --verify-no-changes` + `dotnet build` locally before every commit
- **Dependabot** — weekly PRs for NuGet packages, Docker base images, and GitHub Actions
- **CodeQL** — SAST on every push/PR plus a weekly scheduled scan; findings appear in the GitHub Security tab

### Code fixes surfaced by the new analyzers
- `DatabaseConfiguration.DefaultPort` changed from `readonly` field to `const` (RCS1187)
- `app.Run()` → `await app.RunAsync()` in API `Program.cs` (S6966)

### Suppressions
- `RCS1181` — section-header comments (`// Navigation Properties`) are intentional organizers, not missing XML docs
- `RCS1201` — EF Core fluent config reads better as separate statements than chained calls
- `VSTHRD111` — `ConfigureAwait(false)` is a library concern only; this is an application

## Test plan

- [ ] Clone fresh → `dotnet tool restore && dotnet husky install` → pre-commit hook fires on first commit
- [ ] Introduce a format violation → commit is rejected by the hook
- [ ] `dotnet build src/` → 0 warnings, 0 errors
- [ ] Check GitHub Security tab after merge for CodeQL baseline results
- [ ] Verify Dependabot PRs start appearing on Mondays

🤖 Generated with [Claude Code](https://claude.com/claude-code)