### PR TITLE
fix(ci): run format check before badge branch switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
         if: always()
         run: cat coverage/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
+      - name: Check formatting
+        run: dotnet format --verify-no-changes src/
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
@@ -68,9 +71,6 @@ jobs:
           git add coverage.svg
           git diff --staged --quiet || git commit -m "chore: update coverage badge"
           git push --force origin badges
-
-      - name: Check formatting
-        run: dotnet format --verify-no-changes src/
 
   docker:
     name: Docker — ${{ matrix.name }}


### PR DESCRIPTION
## Summary

- Moves the `Check formatting` step before `Update coverage badge` in the `build-and-test` job
- The badge step checks out an orphan `badges` branch and wipes the working tree (`git rm -rf .`), leaving no `src/` directory — causing `dotnet format --verify-no-changes src/` to fail with a `FileNotFoundException` on every master build

## Root cause

The `Update coverage badge` step ends on the `badges` branch with an empty working tree. Any step that follows and references `src/` will fail because the directory no longer exists in the runner's workspace.

## Test plan

- [ ] Confirm CI passes on master after merge — `Check formatting` runs while the repo is still on the normal checkout