### PR TITLE
feat(users): Change password endpoint

### DIFF
--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
@@ -341,4 +341,110 @@ public sealed class AuthResponseMapperTests
 
         http.Response.Headers.SetCookie.ToString().Should().Contain(AuthMessages.RefreshTokenCookieName);
     }
+
+    // ==========================================================================
+    // GetChangePasswordResult
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetChangePasswordResult_Success_Returns204NoContent()
+    {
+        var http = NewHttp();
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetChangePasswordResult(AuthResult.Ok(), new PasswordPolicy());
+        await result.ExecuteAsync(http);
+
+        http.Response.StatusCode.Should().Be(204);
+    }
+
+    [Fact]
+    public async Task GetChangePasswordResult_InvalidCredentials_Returns400WithMessage()
+    {
+        var http = NewHttp();
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetChangePasswordResult(AuthResult.Fail(AuthError.InvalidCredentials), new PasswordPolicy());
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        Assert.Multiple(() =>
+        {
+            http.Response.StatusCode.Should().Be(400);
+            body.Should().Contain(AuthMessages.InvalidCredentials);
+        });
+    }
+
+    [Fact]
+    public async Task GetChangePasswordResult_PasswordTooShort_Returns422WithPolicyTooShortMessage()
+    {
+        var http = NewHttp();
+        var testee = new TestFixture().CreateTestee();
+        var policy = new PasswordPolicy { MinLength = 16 };
+
+        var result = testee.GetChangePasswordResult(AuthResult.Fail(AuthError.PasswordTooShort), policy);
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        Assert.Multiple(() =>
+        {
+            http.Response.StatusCode.Should().Be(422);
+            body.Should().Contain(policy.TooShortMessage);
+        });
+    }
+
+    [Fact]
+    public async Task GetChangePasswordResult_PasswordTooLong_Returns422WithPolicyTooLongMessage()
+    {
+        var http = NewHttp();
+        var testee = new TestFixture().CreateTestee();
+        var policy = new PasswordPolicy { MaxLength = 64 };
+
+        var result = testee.GetChangePasswordResult(AuthResult.Fail(AuthError.PasswordTooLong), policy);
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        Assert.Multiple(() =>
+        {
+            http.Response.StatusCode.Should().Be(422);
+            body.Should().Contain(policy.TooLongMessage);
+        });
+    }
+
+    [Fact]
+    public async Task GetChangePasswordResult_PasswordPwned_Returns422WithPwnedMessage()
+    {
+        var http = NewHttp();
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetChangePasswordResult(AuthResult.Fail(AuthError.PasswordPwned), new PasswordPolicy());
+        await result.ExecuteAsync(http);
+        var body = await ReadBodyAsync(http.Response);
+
+        Assert.Multiple(() =>
+        {
+            http.Response.StatusCode.Should().Be(422);
+            body.Should().Contain(AuthMessages.PasswordPwned);
+        });
+    }
+
+    [Fact]
+    public void GetChangePasswordResult_ErrorFromOtherContext_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetChangePasswordResult(AuthResult.Fail(AuthError.UsernameTaken), new PasswordPolicy());
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
+
+    [Fact]
+    public void GetChangePasswordResult_UndefinedAuthError_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetChangePasswordResult(AuthResult.Fail((AuthError)999), new PasswordPolicy());
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
 }

--- a/src/Anichron.API.Tests.Unit/Endpoints/UserEndpointsTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/UserEndpointsTests.cs
@@ -1,0 +1,130 @@
+using Anichron.API.Endpoints;
+using Anichron.API.Infrastructure;
+using Anichron.API.Services;
+using Anichron.API.Settings;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+
+namespace Anichron.API.Tests.Unit.Endpoints;
+
+public sealed class UserEndpointsTests
+{
+    private static readonly ChangePasswordRequest ValidRequest = new("OldPass123!", "NewPass456!");
+
+    private static ClaimsPrincipal PrincipalWithGuid(Guid userId)
+        => new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, userId.ToString())]));
+
+    private static ClaimsPrincipal PrincipalWithClaim(string value)
+        => new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, value)]));
+
+    private static ClaimsPrincipal PrincipalWithoutNameIdentifier()
+        => new(new ClaimsIdentity([]));
+
+    // ==========================================================================
+    // Claims parsing
+    // ==========================================================================
+
+    [Fact]
+    public async Task ChangePasswordAsync_MissingNameIdentifierClaim_ReturnsUnauthorized()
+    {
+        var authService = Substitute.For<IAuthService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var options = Options.Create(new PasswordPolicy());
+
+        var result = await UserEndpoints.ChangePasswordAsync(
+            ValidRequest, PrincipalWithoutNameIdentifier(), authService, mapper, options,
+            CancellationToken.None);
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>();
+        await authService.DidNotReceive().ChangePasswordAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_NonGuidNameIdentifierClaim_ReturnsUnauthorized()
+    {
+        var authService = Substitute.For<IAuthService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var options = Options.Create(new PasswordPolicy());
+
+        var result = await UserEndpoints.ChangePasswordAsync(
+            ValidRequest, PrincipalWithClaim("not-a-guid"), authService, mapper, options,
+            CancellationToken.None);
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>();
+        await authService.DidNotReceive().ChangePasswordAsync(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // Happy path
+    // ==========================================================================
+
+    [Fact]
+    public async Task ChangePasswordAsync_ValidClaim_CallsAuthServiceWithCorrectUserId()
+    {
+        var userId = Guid.NewGuid();
+        var authService = Substitute.For<IAuthService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var options = Options.Create(new PasswordPolicy());
+        authService.ChangePasswordAsync(userId, ValidRequest.CurrentPassword, ValidRequest.NewPassword, Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Ok());
+        mapper.GetChangePasswordResult(Arg.Any<AuthResult>(), Arg.Any<PasswordPolicy>())
+            .Returns(Results.NoContent());
+
+        await UserEndpoints.ChangePasswordAsync(
+            ValidRequest, PrincipalWithGuid(userId), authService, mapper, options,
+            CancellationToken.None);
+
+        await authService.Received(1).ChangePasswordAsync(
+            userId, ValidRequest.CurrentPassword, ValidRequest.NewPassword, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_ValidClaim_ReturnsMappedResult()
+    {
+        var userId = Guid.NewGuid();
+        var authService = Substitute.For<IAuthService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var options = Options.Create(new PasswordPolicy());
+        var expectedResult = Results.NoContent();
+        authService.ChangePasswordAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Ok());
+        mapper.GetChangePasswordResult(Arg.Any<AuthResult>(), Arg.Any<PasswordPolicy>())
+            .Returns(expectedResult);
+
+        var result = await UserEndpoints.ChangePasswordAsync(
+            ValidRequest, PrincipalWithGuid(userId), authService, mapper, options,
+            CancellationToken.None);
+
+        result.Should().BeSameAs(expectedResult);
+    }
+
+    // ==========================================================================
+    // Auth service error
+    // ==========================================================================
+
+    [Fact]
+    public async Task ChangePasswordAsync_ValidClaim_AuthServiceReturnsError_ReturnsMappedResult()
+    {
+        var userId = Guid.NewGuid();
+        var authService = Substitute.For<IAuthService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var policy = new PasswordPolicy();
+        var options = Options.Create(policy);
+        var failureResult = AuthResult.Fail(AuthError.InvalidCredentials);
+        var expectedResult = Results.Json(new { error = AuthMessages.InvalidCredentials }, statusCode: 400);
+        authService.ChangePasswordAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(failureResult);
+        mapper.GetChangePasswordResult(failureResult, policy)
+            .Returns(expectedResult);
+
+        var result = await UserEndpoints.ChangePasswordAsync(
+            ValidRequest, PrincipalWithGuid(userId), authService, mapper, options,
+            CancellationToken.None);
+
+        result.Should().BeSameAs(expectedResult);
+        mapper.Received(1).GetChangePasswordResult(failureResult, policy);
+    }
+}

--- a/src/Anichron.API.Tests.Unit/Security/RegistrationValidatorTests.cs
+++ b/src/Anichron.API.Tests.Unit/Security/RegistrationValidatorTests.cs
@@ -151,6 +151,97 @@ public sealed class RegistrationValidatorTests
         await act.Should().ThrowAsync<HttpRequestException>();
     }
 
+    // ==========================================================================
+    // ValidatePasswordAsync
+    // ==========================================================================
+
+    [Theory]
+    [InlineData("short1234")] // 9 chars — below MinLength (12)
+    [InlineData("")]          // 0 chars — below MinLength (12)
+    public async Task ValidatePasswordAsync_PasswordTooShort_ReturnsPasswordTooShort(string password)
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = await testee.ValidatePasswordAsync(password, CancellationToken.None);
+
+        result.Should().Be(AuthError.PasswordTooShort);
+    }
+
+    [Fact]
+    public async Task ValidatePasswordAsync_PasswordTooLong_ReturnsPasswordTooLong()
+    {
+        var testee = new TestFixture()
+            .WithPasswordPolicy(new PasswordPolicy { MaxLength = 10 })
+            .CreateTestee();
+
+        var result = await testee.ValidatePasswordAsync("12characters", CancellationToken.None);
+
+        result.Should().Be(AuthError.PasswordTooLong);
+    }
+
+    [Fact]
+    public async Task ValidatePasswordAsync_PasswordIsPwned_ReturnsPasswordPwned()
+    {
+        var testee = new TestFixture()
+            .WithPwnedPassword(isPwned: true)
+            .CreateTestee();
+
+        var result = await testee.ValidatePasswordAsync(ValidPassword, CancellationToken.None);
+
+        result.Should().Be(AuthError.PasswordPwned);
+    }
+
+    [Fact]
+    public async Task ValidatePasswordAsync_PwnedCheckDisabledAndPasswordPwned_ReturnsNull()
+    {
+        var testee = new TestFixture()
+            .WithPwnedPassword(isPwned: true)
+            .WithPasswordPolicy(new PasswordPolicy { CheckPwnedPasswords = false })
+            .CreateTestee();
+
+        var result = await testee.ValidatePasswordAsync(ValidPassword, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidatePasswordAsync_ValidPassword_ReturnsNull()
+    {
+        var testee = new TestFixture()
+            .WithPwnedPassword(isPwned: false)
+            .CreateTestee();
+
+        var result = await testee.ValidatePasswordAsync(ValidPassword, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidatePasswordAsync_ValidPasswordAtMinLengthBoundary_ReturnsNull()
+    {
+        var testee = new TestFixture()
+            .WithPwnedPassword(isPwned: false)
+            .CreateTestee();
+
+        var result = await testee.ValidatePasswordAsync("123456789012", CancellationToken.None); // exactly 12 chars
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ValidatePasswordAsync_PwnedClientThrows_PropagatesException()
+    {
+        var fixture = new TestFixture();
+        fixture.PwnedClient
+            .IsPwnedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<bool>(new HttpRequestException("Network error")));
+        var testee = fixture.CreateTestee();
+
+        var act = async () => await testee.ValidatePasswordAsync(ValidPassword, CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
     private sealed class TestFixture
     {
         private PasswordPolicy _passwordPolicy = new();

--- a/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
@@ -31,6 +31,9 @@ public sealed class AuthServiceTests
             _unitOfWork
                 .ExecuteInTransactionAsync(Arg.Any<Func<Task<AuthTokens>>>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo => callInfo.Arg<Func<Task<AuthTokens>>>()());
+            _unitOfWork
+                .ExecuteInTransactionAsync(Arg.Any<Func<Task>>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo => callInfo.Arg<Func<Task>>()());
         }
 
         public TestFixture WithPasswordValid()
@@ -87,6 +90,20 @@ public sealed class AuthServiceTests
         public TestFixture WithTokenRefresh(string rawToken, AuthResult<AuthTokens> result)
         {
             TokenService.RefreshAsync(rawToken, Arg.Any<CancellationToken>()).Returns(result);
+            return this;
+        }
+
+        public TestFixture WithUserById(Guid id, User? user)
+        {
+            _users.FindByIdAsync(id, Arg.Any<CancellationToken>()).Returns(user);
+            return this;
+        }
+
+        public TestFixture WithPasswordValidationError(AuthError error)
+        {
+            _validator
+                .ValidatePasswordAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns((AuthError?)error);
             return this;
         }
 
@@ -537,5 +554,135 @@ public sealed class AuthServiceTests
         await testee.RevokeAsync("raw_token", CancellationToken.None);
 
         await fixture.TokenService.Received(1).RevokeAsync("raw_token", Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // ChangePasswordAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task ChangePasswordAsync_NullCurrentPassword_ThrowsArgumentNullException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = async () => await testee.ChangePasswordAsync(Guid.Empty, null!, "new_password", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("currentPassword");
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_NullNewPassword_ThrowsArgumentNullException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = async () => await testee.ChangePasswordAsync(Guid.Empty, "current_password", null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("newPassword");
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_UserNotFound_ReturnsInvalidCredentials()
+    {
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var fixture = new TestFixture().WithUserById(userId, null);
+        var testee = fixture.CreateTestee();
+
+        var result = await testee.ChangePasswordAsync(userId, "current_password", "new_password", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(AuthError.InvalidCredentials);
+        });
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_WrongCurrentPassword_ReturnsInvalidCredentials()
+    {
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var user = new User { Id = userId, PasswordHash = "stored_hash" };
+        var fixture = new TestFixture().WithUserById(userId, user);
+        var testee = fixture.CreateTestee();
+
+        var result = await testee.ChangePasswordAsync(userId, "wrong_password", "new_password", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(AuthError.InvalidCredentials);
+        });
+    }
+
+    [Theory]
+    [InlineData(AuthError.PasswordTooShort)]
+    [InlineData(AuthError.PasswordTooLong)]
+    [InlineData(AuthError.PasswordPwned)]
+    public async Task ChangePasswordAsync_NewPasswordFailsValidation_ReturnsValidationError(AuthError validationError)
+    {
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var user = new User { Id = userId, PasswordHash = "stored_hash" };
+        var fixture = new TestFixture()
+            .WithUserById(userId, user)
+            .WithPasswordValid()
+            .WithPasswordValidationError(validationError);
+        var testee = fixture.CreateTestee();
+
+        var result = await testee.ChangePasswordAsync(userId, "current_password", "weak", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(validationError);
+        });
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_ValidPasswords_ReturnsOk()
+    {
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var user = new User { Id = userId, PasswordHash = "stored_hash" };
+        var fixture = new TestFixture()
+            .WithUserById(userId, user)
+            .WithPasswordValid();
+        var testee = fixture.CreateTestee();
+
+        var result = await testee.ChangePasswordAsync(userId, "current_password", "new_password", CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_ValidPasswords_UpdatesPasswordHashAndClearsMustChangePassword()
+    {
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var user = new User { Id = userId, PasswordHash = "stored_hash", MustChangePassword = true };
+        var fixture = new TestFixture()
+            .WithUserById(userId, user)
+            .WithPasswordValid();
+        var testee = fixture.CreateTestee();
+
+        await testee.ChangePasswordAsync(userId, "current_password", "new_password", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            user.PasswordHash.Should().Be("hashed_value");
+            user.MustChangePassword.Should().BeFalse();
+        });
+    }
+
+    [Fact]
+    public async Task ChangePasswordAsync_ValidPasswords_RevokesAllSessions()
+    {
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var user = new User { Id = userId, PasswordHash = "stored_hash" };
+        var fixture = new TestFixture()
+            .WithUserById(userId, user)
+            .WithPasswordValid();
+        var testee = fixture.CreateTestee();
+
+        await testee.ChangePasswordAsync(userId, "current_password", "new_password", CancellationToken.None);
+
+        await fixture.TokenService.Received(1)
+            .MarkAllSessionsRevokedAsync(userId, Arg.Any<Instant>(), Arg.Any<CancellationToken>());
     }
 }

--- a/src/Anichron.API.Tests.Unit/Services/TokenServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/TokenServiceTests.cs
@@ -288,4 +288,21 @@ public sealed class TokenServiceTests
         token.RevokedAt.Should().Be(FixedNow);
         await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
+
+    // ==========================================================================
+    // MarkAllSessionsRevokedAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task MarkAllSessionsRevokedAsync_CallsRevokeAllActiveByUserIdWithoutSaving()
+    {
+        var userId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+        var fixture = new TestFixture();
+        var testee = fixture.CreateTestee();
+
+        await testee.MarkAllSessionsRevokedAsync(userId, FixedNow, CancellationToken.None);
+
+        await fixture.Tokens.Received(1).RevokeAllActiveByUserIdAsync(userId, FixedNow, Arg.Any<CancellationToken>());
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
 }

--- a/src/Anichron.API/Endpoints/AuthResponseMapper.cs
+++ b/src/Anichron.API/Endpoints/AuthResponseMapper.cs
@@ -11,6 +11,7 @@ public interface IAuthResponseMapper
     IResult GetRegistrationResult(AuthResult<AuthTokens> result, HttpContext http, PasswordPolicy passwordPolicy, UsernamePolicy usernamePolicy);
     IResult GetLoginResult(AuthResult<AuthTokens> result, HttpContext http, bool setCookie);
     IResult GetRefreshResult(AuthResult<AuthTokens> result, HttpContext http, bool setCookie);
+    IResult GetChangePasswordResult(AuthResult result, PasswordPolicy passwordPolicy);
     void ClearRefreshCookie(HttpContext http);
 }
 
@@ -104,6 +105,39 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
         }
 
         return BuildTokenResponse(result.Value!, http, setCookie);
+    }
+
+    public IResult GetChangePasswordResult(AuthResult result, PasswordPolicy passwordPolicy)
+    {
+        if (result.IsSuccess)
+            return Results.NoContent();
+
+        return result.Error switch
+        {
+            AuthError.InvalidCredentials => Results.Json(
+                data: new { error = AuthMessages.InvalidCredentials },
+                statusCode: StatusCodes.Status400BadRequest),
+            AuthError.PasswordTooShort => Results.Json(
+                data: new { error = passwordPolicy.TooShortMessage },
+                statusCode: StatusCodes.Status422UnprocessableEntity),
+            AuthError.PasswordTooLong => Results.Json(
+                data: new { error = passwordPolicy.TooLongMessage },
+                statusCode: StatusCodes.Status422UnprocessableEntity),
+            AuthError.PasswordPwned => Results.Json(
+                data: new { error = AuthMessages.PasswordPwned },
+                statusCode: StatusCodes.Status422UnprocessableEntity),
+            // Not reachable from ChangePasswordAsync; signals a logic bug if reached.
+            AuthError.None or
+            AuthError.UsernameTaken or
+            AuthError.EmailTaken or
+            AuthError.TokenInvalid or
+            AuthError.InvalidUsername or
+            AuthError.InvalidEmail or
+            AuthError.AccountDisabled or
+            AuthError.AccountTemporarilyLocked
+                => throw new UnreachableException($"Unexpected AuthError in ChangePassword: {result.Error}"),
+            _ => throw new UnreachableException($"Unhandled AuthError in ChangePassword: {result.Error}"),
+        };
     }
 
     public void ClearRefreshCookie(HttpContext http)

--- a/src/Anichron.API/Endpoints/UserEndpoints.cs
+++ b/src/Anichron.API/Endpoints/UserEndpoints.cs
@@ -1,0 +1,36 @@
+using Anichron.API.Infrastructure;
+using Anichron.API.Services;
+using Anichron.API.Settings;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+
+namespace Anichron.API.Endpoints;
+
+public static class UserEndpoints
+{
+    public static IEndpointRouteBuilder MapUserEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("users").WithTags("Users");
+        group.MapPost("/me/password", ChangePasswordAsync)
+             .RequireAuthorization()
+             .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        return app;
+    }
+
+    internal static async Task<IResult> ChangePasswordAsync(
+        ChangePasswordRequest req,
+        ClaimsPrincipal user,
+        IAuthService auth,
+        IAuthResponseMapper mapper,
+        IOptions<PasswordPolicy> passwordPolicyOptions,
+        CancellationToken ct)
+    {
+        if (!Guid.TryParse(user.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
+            return Results.Unauthorized();
+
+        var result = await auth.ChangePasswordAsync(userId, req.CurrentPassword, req.NewPassword, ct);
+        return mapper.GetChangePasswordResult(result, passwordPolicyOptions.Value);
+    }
+}
+
+public sealed record ChangePasswordRequest(string CurrentPassword, string NewPassword);

--- a/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
@@ -14,6 +14,7 @@ public static partial class ApplicationExtensions
         {
             var api = app.MapGroup("/api/v1");
             api.MapAuthEndpoints();
+            api.MapUserEndpoints();
             return app;
         }
 

--- a/src/Anichron.API/Security/RegistrationValidator.cs
+++ b/src/Anichron.API/Security/RegistrationValidator.cs
@@ -8,6 +8,7 @@ namespace Anichron.API.Security;
 public interface IRegistrationValidator
 {
     Task<AuthError?> ValidateAsync(string username, string email, string password, CancellationToken ct);
+    Task<AuthError?> ValidatePasswordAsync(string password, CancellationToken ct);
 }
 
 public sealed class RegistrationValidator(
@@ -30,6 +31,23 @@ public sealed class RegistrationValidator(
         if (!IsValidEmail(email))
             return AuthError.InvalidEmail;
 
+        if (password.Length < _passwordPolicy.MinLength)
+            return AuthError.PasswordTooShort;
+
+        if (password.Length > _passwordPolicy.MaxLength)
+            return AuthError.PasswordTooLong;
+
+        // IDE0046 suppressed: collapsing an async condition into a ternary reduces readability
+#pragma warning disable IDE0046
+        if (_passwordPolicy.CheckPwnedPasswords && await pwnedClient.IsPwnedAsync(password, ct))
+#pragma warning restore IDE0046
+            return AuthError.PasswordPwned;
+
+        return null;
+    }
+
+    public async Task<AuthError?> ValidatePasswordAsync(string password, CancellationToken ct)
+    {
         if (password.Length < _passwordPolicy.MinLength)
             return AuthError.PasswordTooShort;
 

--- a/src/Anichron.API/Services/AuthService.cs
+++ b/src/Anichron.API/Services/AuthService.cs
@@ -34,10 +34,18 @@ public sealed record AuthResult<T>
     public int? RetryAfterSeconds { get; init; }
 }
 
-public static class AuthResult
+public sealed record AuthResult
 {
+    public AuthError? Error { get; init; }
+    public bool IsSuccess => Error is null;
+    public int? RetryAfterSeconds { get; init; }
+
+    public static AuthResult Ok() => new();
     public static AuthResult<T> Ok<T>(T value) => new() { Value = value };
+
+    public static AuthResult Fail(AuthError error) => new() { Error = error };
     public static AuthResult<T> Fail<T>(AuthError error) => new() { Error = error };
+
     public static AuthResult<T> Locked<T>(int retryAfterSeconds) => new()
     {
         Error = AuthError.AccountTemporarilyLocked,
@@ -51,6 +59,7 @@ public interface IAuthService
     Task<AuthResult<AuthTokens>> LoginAsync(string usernameOrEmail, string password, CancellationToken ct);
     Task<AuthResult<AuthTokens>> RefreshAsync(string rawToken, CancellationToken ct);
     Task RevokeAsync(string rawToken, CancellationToken ct);
+    Task<AuthResult> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword, CancellationToken ct);
 }
 
 public sealed class AuthService(
@@ -157,6 +166,31 @@ public sealed class AuthService(
 
     public Task RevokeAsync(string rawToken, CancellationToken ct)
         => tokenService.RevokeAsync(rawToken, ct);
+
+    public async Task<AuthResult> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(currentPassword);
+        ArgumentNullException.ThrowIfNull(newPassword);
+
+        var user = await users.FindByIdAsync(userId, ct);
+        if (user is null || !passwordHasher.Verify(currentPassword, user.PasswordHash))
+            return AuthResult.Fail(AuthError.InvalidCredentials);
+
+        var error = await validator.ValidatePasswordAsync(newPassword, ct);
+        if (error is not null)
+            return AuthResult.Fail(error.Value);
+
+        await unitOfWork.ExecuteInTransactionAsync(async () =>
+        {
+            user.PasswordHash = passwordHasher.Hash(newPassword);
+            user.MustChangePassword = false;
+            var now = clock.GetCurrentInstant();
+            await tokenService.MarkAllSessionsRevokedAsync(userId, now, ct);
+            await unitOfWork.SaveChangesAsync(ct);
+        }, ct);
+
+        return AuthResult.Ok();
+    }
 
     private async Task RecordFailedLoginAttemptAsync(User user, Instant now, CancellationToken ct)
     {

--- a/src/Anichron.API/Services/TokenService.cs
+++ b/src/Anichron.API/Services/TokenService.cs
@@ -13,6 +13,7 @@ public interface ITokenService
     Task<AuthTokens> IssueAsync(User user, CancellationToken ct);
     Task<AuthResult<AuthTokens>> RefreshAsync(string rawToken, CancellationToken ct);
     Task RevokeAsync(string rawToken, CancellationToken ct);
+    Task MarkAllSessionsRevokedAsync(Guid userId, Instant revokedAt, CancellationToken ct);
 }
 
 public sealed class TokenService(
@@ -91,6 +92,9 @@ public sealed class TokenService(
         stored.RevokedAt = clock.GetCurrentInstant();
         await unitOfWork.SaveChangesAsync(ct);
     }
+
+    public Task MarkAllSessionsRevokedAsync(Guid userId, Instant revokedAt, CancellationToken ct)
+        => tokens.RevokeAllActiveByUserIdAsync(userId, revokedAt, ct);
 
     private static string GenerateRefreshToken()
         => Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));

--- a/src/Anichron.Core/Data/AnichronDbContext.cs
+++ b/src/Anichron.Core/Data/AnichronDbContext.cs
@@ -22,6 +22,13 @@ public class AnichronDbContext(DbContextOptions<AnichronDbContext> options) : Db
         return result;
     }
 
+    public async Task ExecuteInTransactionAsync(Func<Task> action, CancellationToken ct = default)
+    {
+        await using var tx = await Database.BeginTransactionAsync(ct);
+        await action();
+        await tx.CommitAsync(ct);
+    }
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         base.OnModelCreating(modelBuilder);

--- a/src/Anichron.Core/Data/IUnitOfWork.cs
+++ b/src/Anichron.Core/Data/IUnitOfWork.cs
@@ -4,4 +4,5 @@ public interface IUnitOfWork
 {
     Task<int> SaveChangesAsync(CancellationToken ct = default);
     Task<T> ExecuteInTransactionAsync<T>(Func<Task<T>> action, CancellationToken ct = default);
+    Task ExecuteInTransactionAsync(Func<Task> action, CancellationToken ct = default);
 }

--- a/src/Anichron.Core/Data/Repository/UserRepository.cs
+++ b/src/Anichron.Core/Data/Repository/UserRepository.cs
@@ -8,6 +8,7 @@ public interface IUserRepository
     Task<bool> AnyAsync(CancellationToken ct);
     Task<bool> AnyByUsernameAsync(string username, CancellationToken ct);
     Task<bool> AnyByEmailAsync(string email, CancellationToken ct);
+    Task<User?> FindByIdAsync(Guid id, CancellationToken ct);
     Task<User?> FindByCredentialAsync(string normalizedCredential, CancellationToken ct);
     Task<User?> FindAdminByUsernameAsync(string username, CancellationToken ct);
     Task<List<User>> FindAdminsAsync(int take, CancellationToken ct);
@@ -24,6 +25,9 @@ public sealed class EfUserRepository(AnichronDbContext db) : IUserRepository
 
     public Task<bool> AnyByEmailAsync(string email, CancellationToken ct)
         => db.Users.AnyAsync(u => u.Email == email, ct);
+
+    public async Task<User?> FindByIdAsync(Guid id, CancellationToken ct)
+        => await db.Users.FindAsync([id], ct);
 
     public Task<User?> FindByCredentialAsync(string normalizedCredential, CancellationToken ct)
         => db.Users.FirstOrDefaultAsync(


### PR DESCRIPTION
## Summary

- `POST /api/v1/users/me/password` — authenticated user changes their own password
- Verifies the current password against the stored Argon2id hash; returns `400` without revealing which field is wrong
- Validates the new password against the same strength policy used at registration (length + HaveIBeenPwned check)
- On success: atomically updates the password hash, clears `MustChangePassword`, and revokes all active refresh tokens — forcing re-login on all devices
- Returns `204 No Content` on success

This unblocks the first-login flow: the bootstrap admin is created with `MustChangePassword = true` but previously had no endpoint to fulfil the requirement.

## Changes

**Core additions:**
- `IUnitOfWork` — non-generic `ExecuteInTransactionAsync(Func<Task>)` overload (no phantom return type needed)
- `IUserRepository` — `FindByIdAsync(Guid, CancellationToken)`
- `ITokenService` — `MarkAllSessionsRevokedAsync(Guid userId, Instant, CancellationToken)` — marks tokens revoked without saving, so the caller controls the transaction boundary
- `IRegistrationValidator` — `ValidatePasswordAsync(string, CancellationToken)` — extracts the password-only checks from `ValidateAsync` for reuse

**Service layer:**
- `AuthService.ChangePasswordAsync` — implementation following the spec above
- `AuthResult` (non-generic record) — replaces the previous `Unit` struct approach; models operations that succeed with no payload (analogous to `Task` vs `Task<T>`)

**Endpoint:**
- `UserEndpoints` — new file, maps `POST /users/me/password` under `/api/v1`; wired into `MapApiEndpoints()`
- `IAuthResponseMapper.GetChangePasswordResult` — password error-to-response mapping lives alongside the other auth mappers rather than inline in the endpoint

**Tests:** `AuthServiceTests`, `TokenServiceTests`, `RegistrationValidatorTests`, `AuthResponseMapperTests`, `UserEndpointsTests`

## Test plan

- [ ] `POST /api/v1/users/me/password` with correct current password and strong new password → `204`
- [ ] Wrong current password → `400 { "error": "..." }` (same message regardless of whether user exists)
- [ ] New password too short / too long / pwned → `422`
- [ ] Unauthenticated request → `401`
- [ ] All 203 unit tests pass (`dotnet test src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)