### PR TITLE
feat(auth): Enforce must_change_password on all protected endpoints

### DIFF
--- a/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
+++ b/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
@@ -63,6 +63,21 @@ public sealed class MustChangePasswordMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_AuthenticatedWithClaimValueFalse_CallsNext()
+    {
+        var context = BuildContext(
+            Authenticated(new Claim(AppClaimTypes.MustChangePassword, "false")),
+            HttpMethods.Get, "/api/v1/some/endpoint");
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
     public async Task InvokeAsync_AuthenticatedWithClaim_PostChangePasswordPath_CallsNext()
     {
         var context = BuildContext(Authenticated(MustChangeClaim()), HttpMethods.Post, ChangePasswordPath);

--- a/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
+++ b/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
@@ -1,0 +1,135 @@
+using Anichron.API.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace Anichron.API.Tests.Unit.Infrastructure;
+
+public sealed class MustChangePasswordMiddlewareTests
+{
+    private const string ChangePasswordPath = "/api/v1/users/me/password";
+    private const string LogoutPath = "/api/v1/auth/logout";
+
+    private static DefaultHttpContext BuildContext(ClaimsPrincipal user, string method, string path)
+    {
+        var context = new DefaultHttpContext { User = user };
+        context.Request.Method = method;
+        context.Request.Path = path;
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static ClaimsPrincipal Authenticated(params Claim[] claims)
+        => new(new ClaimsIdentity(claims, authenticationType: "Test"));
+
+    private static ClaimsPrincipal Unauthenticated()
+        => new(new ClaimsIdentity());
+
+    private static Claim MustChangeClaim() => new(AppClaimTypes.MustChangePassword, "true");
+
+    private static async Task<string> ReadBodyAsync(HttpResponse response)
+    {
+        response.Body.Seek(0, SeekOrigin.Begin);
+        return await new StreamReader(response.Body).ReadToEndAsync();
+    }
+
+    // ==========================================================================
+    // Calls next
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_Unauthenticated_CallsNext()
+    {
+        var context = BuildContext(Unauthenticated(), HttpMethods.Get, "/api/v1/some/endpoint");
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AuthenticatedWithoutClaim_CallsNext()
+    {
+        var context = BuildContext(Authenticated(), HttpMethods.Get, "/api/v1/some/endpoint");
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AuthenticatedWithClaim_PostChangePasswordPath_CallsNext()
+    {
+        var context = BuildContext(Authenticated(MustChangeClaim()), HttpMethods.Post, ChangePasswordPath);
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AuthenticatedWithClaim_PostLogoutPath_CallsNext()
+    {
+        var context = BuildContext(Authenticated(MustChangeClaim()), HttpMethods.Post, LogoutPath);
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(200);
+    }
+
+    // ==========================================================================
+    // Returns 403
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_AuthenticatedWithClaim_NonExemptGetPath_Returns403WithMessage()
+    {
+        var context = BuildContext(Authenticated(MustChangeClaim()), HttpMethods.Get, "/api/v1/some/endpoint");
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+        var body = await ReadBodyAsync(context.Response);
+
+        nextCalled.Should().BeFalse();
+        context.Response.StatusCode.Should().Be(403);
+        body.Should().Contain("Password change required before continuing.");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AuthenticatedWithClaim_NonExemptPostPath_Returns403()
+    {
+        var context = BuildContext(Authenticated(MustChangeClaim()), HttpMethods.Post, "/api/v1/some/endpoint");
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeFalse();
+        context.Response.StatusCode.Should().Be(403);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AuthenticatedWithClaim_GetChangePasswordPath_Returns403()
+    {
+        var context = BuildContext(Authenticated(MustChangeClaim()), HttpMethods.Get, ChangePasswordPath);
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeFalse();
+        context.Response.StatusCode.Should().Be(403);
+    }
+}

--- a/src/Anichron.API/Endpoints/AuthEndpoints.cs
+++ b/src/Anichron.API/Endpoints/AuthEndpoints.cs
@@ -10,15 +10,15 @@ public static class AuthEndpoints
 {
     public static IEndpointRouteBuilder MapAuthEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("auth").WithTags("Auth");
+        var group = app.MapGroup(ApiPaths.Auth.Group).WithTags("Auth");
 
-        group.MapPost("/register", RegisterAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
-        group.MapPost("/login", LoginWebAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
-        group.MapPost("/login/mobile", LoginMobileAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
-        group.MapPost("/refresh", RefreshAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Refresh);
-        group.MapPost("/logout", LogoutAsync).RequireAuthorization();
-        group.MapPost("/password-reset/request", PasswordResetRequest).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
-        group.MapPost("/password-reset/confirm", PasswordResetConfirm).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapPost(ApiPaths.Auth.Register, RegisterAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapPost(ApiPaths.Auth.Login, LoginWebAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapPost(ApiPaths.Auth.LoginMobile, LoginMobileAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapPost(ApiPaths.Auth.Refresh, RefreshAsync).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Refresh);
+        group.MapPost(ApiPaths.Auth.Logout, LogoutAsync).RequireAuthorization();
+        group.MapPost(ApiPaths.Auth.PasswordResetRequest, PasswordResetRequest).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapPost(ApiPaths.Auth.PasswordResetConfirm, PasswordResetConfirm).AllowAnonymous().RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
 
         return app;
     }

--- a/src/Anichron.API/Endpoints/UserEndpoints.cs
+++ b/src/Anichron.API/Endpoints/UserEndpoints.cs
@@ -10,8 +10,8 @@ public static class UserEndpoints
 {
     public static IEndpointRouteBuilder MapUserEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup("users").WithTags("Users");
-        group.MapPost("/me/password", ChangePasswordAsync)
+        var group = app.MapGroup(ApiPaths.Users.Group).WithTags("Users");
+        group.MapPost(ApiPaths.Users.ChangePassword, ChangePasswordAsync)
              .RequireAuthorization()
              .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
         return app;

--- a/src/Anichron.API/Infrastructure/ApiPaths.cs
+++ b/src/Anichron.API/Infrastructure/ApiPaths.cs
@@ -1,0 +1,24 @@
+namespace Anichron.API.Infrastructure;
+
+internal static class ApiPaths
+{
+    internal const string Base = "/api/v1";
+
+    internal static class Auth
+    {
+        internal const string Group = "auth";
+        internal const string Register = "/register";
+        internal const string Login = "/login";
+        internal const string LoginMobile = "/login/mobile";
+        internal const string Refresh = "/refresh";
+        internal const string Logout = "/logout";
+        internal const string PasswordResetRequest = "/password-reset/request";
+        internal const string PasswordResetConfirm = "/password-reset/confirm";
+    }
+
+    internal static class Users
+    {
+        internal const string Group = "users";
+        internal const string ChangePassword = "/me/password";
+    }
+}

--- a/src/Anichron.API/Infrastructure/AppClaimTypes.cs
+++ b/src/Anichron.API/Infrastructure/AppClaimTypes.cs
@@ -1,0 +1,6 @@
+namespace Anichron.API.Infrastructure;
+
+internal static class AppClaimTypes
+{
+    internal const string MustChangePassword = "must_change_password";
+}

--- a/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
@@ -12,7 +12,7 @@ public static partial class ApplicationExtensions
     {
         public WebApplication MapApiEndpoints()
         {
-            var api = app.MapGroup("/api/v1");
+            var api = app.MapGroup(ApiPaths.Base);
             api.MapAuthEndpoints();
             api.MapUserEndpoints();
             return app;

--- a/src/Anichron.API/Infrastructure/AuthMessages.cs
+++ b/src/Anichron.API/Infrastructure/AuthMessages.cs
@@ -8,6 +8,7 @@ internal static class AuthMessages
     internal const string PasswordPwned = "This password has appeared in a known data breach. Please choose a different one.";
     internal const string InvalidCredentials = "The username, email, or password is incorrect.";
     internal const string AccountDisabled = "This account has been disabled. Please contact an administrator.";
+    internal const string MustChangePassword = "Password change required before continuing.";
 
     internal static string AccountTemporarilyLocked(int secondsRemaining) => $"Too many failed login attempts. Please try again in {secondsRemaining} second{(secondsRemaining == 1 ? string.Empty : "s")}.";
     internal const string RefreshTokenRequired = "Refresh token is required.";

--- a/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
+++ b/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
@@ -1,0 +1,30 @@
+namespace Anichron.API.Infrastructure;
+
+internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
+{
+    private static readonly PathString ChangePasswordPath =
+        new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Users.ChangePassword}");
+
+    private static readonly PathString LogoutPath =
+        new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Auth.Logout}");
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.User.Identity?.IsAuthenticated == true
+            && context.User.HasClaim(AppClaimTypes.MustChangePassword, "true")
+            && !IsExemptPostRequest(context.Request))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsJsonAsync(new { error = AuthMessages.MustChangePassword });
+            return;
+        }
+
+        await next(context);
+    }
+
+    private static bool IsExemptPostRequest(HttpRequest request)
+    {
+        return request.Method == HttpMethods.Post
+            && (request.Path == ChangePasswordPath || request.Path == LogoutPath);
+    }
+}

--- a/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
+++ b/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
@@ -6,7 +6,7 @@ internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
         new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Users.ChangePassword}");
 
     private static readonly PathString LogoutPath =
-        new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Auth.Logout}");
+        new($"{ApiPaths.Base}/{ApiPaths.Auth.Group}{ApiPaths.Auth.Logout}");
 
     public async Task InvokeAsync(HttpContext context)
     {

--- a/src/Anichron.API/Program.cs
+++ b/src/Anichron.API/Program.cs
@@ -22,6 +22,7 @@ app.UseHttpsRedirection();
 app.UseCors();
 app.UseRateLimiter();
 app.UseAuthentication();
+app.UseMiddleware<MustChangePasswordMiddleware>();
 app.UseAuthorization();
 
 app.MapApiEndpoints();

--- a/src/Anichron.API/Security/JwtFactory.cs
+++ b/src/Anichron.API/Security/JwtFactory.cs
@@ -1,3 +1,4 @@
+using Anichron.API.Infrastructure;
 using Anichron.API.Settings;
 using Anichron.Core.Domain;
 using Microsoft.Extensions.Options;
@@ -41,7 +42,7 @@ public sealed class JwtFactory : IJwtFactory
         };
 
         if (user.MustChangePassword)
-            claims.Add(new Claim("must_change_password", "true"));
+            claims.Add(new Claim(AppClaimTypes.MustChangePassword, "true"));
 
         var token = new JwtSecurityToken(
             issuer: _settings.Issuer,


### PR DESCRIPTION
## Summary

- Adds `MustChangePasswordMiddleware` that intercepts requests from users whose JWT carries `must_change_password: "true"` and returns `403 Forbidden` before the request reaches any endpoint
- Two paths are exempt: `POST /api/v1/users/me/password` (so the user can fulfil the requirement) and `POST /api/v1/auth/logout` (so the user can always sign out)
- Extracts `AppClaimTypes.MustChangePassword` constant to eliminate the hardcoded `"must_change_password"` string in both `JwtFactory` and the middleware
- Middleware sits between `UseAuthentication()` and `UseAuthorization()` — runs after the JWT is validated and `HttpContext.User` is populated, short-circuits before authorization policy evaluation

## Why middleware, not an authorization policy

A custom `IAuthorizationRequirement` would require a custom `IAuthorizationMiddlewareResultHandler` to write the JSON error body. Middleware keeps the logic in one place, the exempt-path list is visible, and the response shape is trivial to control.

## Complete first-login flow (closes the loop with #85)

1. Bootstrap admin logs in → JWT contains `must_change_password: "true"`
2. Any request other than the two exempt paths → `403 { "error": "Password change required before continuing." }`
3. `POST /api/v1/users/me/password` → `204` — password updated, `MustChangePassword` cleared, all sessions revoked
4. Re-login → new JWT has no claim → unrestricted access

## Test plan

- [ ] All 182 unit tests pass (`dotnet test src/`)
- [ ] Request with valid JWT (no claim) → passes through normally
- [ ] Request with JWT containing `must_change_password: "true"` → `403`
- [ ] `POST /api/v1/users/me/password` with the claim → `204` (not blocked)
- [ ] `POST /api/v1/auth/logout` with the claim → proceeds normally (not blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)