### PR TITLE
feat(users): GET /api/v1/users/me — current user profile endpoint (#98)

### DIFF
--- a/src/Anichron.API.Tests.Unit/Endpoints/UserEndpointsTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/UserEndpointsTests.cs
@@ -2,6 +2,8 @@ using Anichron.API.Endpoints;
 using Anichron.API.Infrastructure;
 using Anichron.API.Services;
 using Anichron.API.Settings;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using System.Security.Claims;
@@ -22,7 +24,79 @@ public sealed class UserEndpointsTests
         => new(new ClaimsIdentity([]));
 
     // ==========================================================================
-    // Claims parsing
+    // GetMeAsync — claims parsing
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetMeAsync_MissingNameIdentifierClaim_ReturnsUnauthorized()
+    {
+        var repo = Substitute.For<IUserRepository>();
+
+        var result = await UserEndpoints.GetMeAsync(
+            PrincipalWithoutNameIdentifier(), repo, CancellationToken.None);
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>();
+        await repo.DidNotReceive().FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetMeAsync_NonGuidNameIdentifierClaim_ReturnsUnauthorized()
+    {
+        var repo = Substitute.For<IUserRepository>();
+
+        var result = await UserEndpoints.GetMeAsync(
+            PrincipalWithClaim("not-a-guid"), repo, CancellationToken.None);
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult>();
+        await repo.DidNotReceive().FindByIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // GetMeAsync — happy path
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetMeAsync_UserFound_ReturnsOkWithProfile()
+    {
+        var userId = Guid.NewGuid();
+        var dbUser = new User
+        {
+            Id = userId,
+            Username = "alice",
+            Email = "alice@example.com",
+            IsAdmin = false,
+            MustChangePassword = false
+        };
+        var repo = Substitute.For<IUserRepository>();
+        repo.FindByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(dbUser);
+
+        var result = await UserEndpoints.GetMeAsync(
+            PrincipalWithGuid(userId), repo, CancellationToken.None);
+
+        var ok = result.Should()
+            .BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<UserProfileResponse>>().Subject;
+        ok.Value.Should().Be(new UserProfileResponse(userId, "alice", "alice@example.com", false, false));
+    }
+
+    // ==========================================================================
+    // GetMeAsync — not found
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetMeAsync_UserNotFound_ReturnsNotFound()
+    {
+        var userId = Guid.NewGuid();
+        var repo = Substitute.For<IUserRepository>();
+        repo.FindByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await UserEndpoints.GetMeAsync(
+            PrincipalWithGuid(userId), repo, CancellationToken.None);
+
+        result.Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.NotFound>();
+    }
+
+    // ==========================================================================
+    // ChangePasswordAsync — claims parsing
     // ==========================================================================
 
     [Fact]

--- a/src/Anichron.API/Endpoints/UserEndpoints.cs
+++ b/src/Anichron.API/Endpoints/UserEndpoints.cs
@@ -1,6 +1,7 @@
 using Anichron.API.Infrastructure;
 using Anichron.API.Services;
 using Anichron.API.Settings;
+using Anichron.Core.Data.Repository;
 using Microsoft.Extensions.Options;
 using System.Security.Claims;
 
@@ -11,10 +12,26 @@ public static class UserEndpoints
     public static IEndpointRouteBuilder MapUserEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup(ApiPaths.Users.Group).WithTags("Users");
+        group.MapGet(ApiPaths.Users.Me, GetMeAsync)
+             .RequireAuthorization();
         group.MapPost(ApiPaths.Users.ChangePassword, ChangePasswordAsync)
              .RequireAuthorization()
              .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
         return app;
+    }
+
+    internal static async Task<IResult> GetMeAsync(
+        ClaimsPrincipal user,
+        IUserRepository users,
+        CancellationToken ct)
+    {
+        if (!Guid.TryParse(user.FindFirstValue(ClaimTypes.NameIdentifier), out var userId))
+            return Results.Unauthorized();
+
+        var found = await users.FindByIdAsync(userId, ct);
+        return found is null
+            ? Results.NotFound()
+            : Results.Ok(new UserProfileResponse(found.Id, found.Username, found.Email, found.IsAdmin, found.MustChangePassword));
     }
 
     internal static async Task<IResult> ChangePasswordAsync(
@@ -34,3 +51,4 @@ public static class UserEndpoints
 }
 
 public sealed record ChangePasswordRequest(string CurrentPassword, string NewPassword);
+public sealed record UserProfileResponse(Guid Id, string Username, string Email, bool IsAdmin, bool MustChangePassword);

--- a/src/Anichron.API/Infrastructure/ApiPaths.cs
+++ b/src/Anichron.API/Infrastructure/ApiPaths.cs
@@ -19,6 +19,7 @@ internal static class ApiPaths
     internal static class Users
     {
         internal const string Group = "users";
-        internal const string ChangePassword = "/me/password";
+        internal const string Me = "/me";
+        internal const string ChangePassword = $"{Me}/password";
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #98 — the `GET /api/v1/users/me` endpoint that every frontend session calls after login to determine the user's display name, admin status, and whether a password change is required.

- Adds `GET /api/v1/users/me` (requires JWT bearer auth)
- Returns `200` with `{ id, username, email, isAdmin, mustChangePassword }`
- Returns `401` if the `sub` claim is missing or not a valid GUID
- Returns `404` if the user no longer exists (e.g. deleted after token was issued)
- No sensitive fields exposed (`passwordHash`, `failedLoginAttempts`, `lockedUntil`)
- Adds `ApiPaths.Users.Me` constant; `ChangePassword` now derives from it (`$"{Me}/password"`)

## Test plan

- [ ] `GetMeAsync_MissingNameIdentifierClaim_ReturnsUnauthorized`
- [ ] `GetMeAsync_NonGuidNameIdentifierClaim_ReturnsUnauthorized`
- [ ] `GetMeAsync_UserFound_ReturnsOkWithProfile` — verifies all 5 response fields
- [ ] `GetMeAsync_UserNotFound_ReturnsNotFound`
- [ ] All 235 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)