### PR TITLE
feat(users): Admin creates user directly — POST /api/v1/users (#99)

### DIFF
--- a/src/Anichron.API.Tests.Unit/Endpoints/AdminEndpointsTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AdminEndpointsTests.cs
@@ -1,0 +1,48 @@
+using Anichron.API.Endpoints;
+using Anichron.API.Services;
+using Microsoft.AspNetCore.Http;
+
+namespace Anichron.API.Tests.Unit.Endpoints;
+
+public sealed class AdminEndpointsTests
+{
+    private static readonly CreateAdminUserRequest ValidRequest = new("alice", "alice@example.com");
+
+    // ==========================================================================
+    // Delegates to mapper
+    // ==========================================================================
+
+    [Fact]
+    public async Task CreateUserAsync_CallsMapperWithServiceResult()
+    {
+        var userId = Guid.NewGuid();
+        var serviceResult = AuthResult.Ok(new AdminCreatedUser(userId, "alice", "alice@example.com", "TempPass=="));
+        var expectedResult = Results.Created($"/api/v1/users/{userId}", new AdminCreatedUserResponse(userId, "alice", "alice@example.com", "TempPass=="));
+        var auth = Substitute.For<IAuthService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        auth.AdminCreateUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(serviceResult);
+        mapper.GetAdminCreateUserResult(serviceResult).Returns(expectedResult);
+
+        var result = await AdminEndpoints.CreateUserAsync(ValidRequest, auth, mapper, CancellationToken.None);
+
+        result.Should().BeSameAs(expectedResult);
+        mapper.Received(1).GetAdminCreateUserResult(serviceResult);
+    }
+
+    [Fact]
+    public async Task CreateUserAsync_CallsServiceWithRequestValues()
+    {
+        var auth = Substitute.For<IAuthService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        auth.AdminCreateUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(AuthResult.Ok(new AdminCreatedUser(Guid.NewGuid(), "alice", "alice@example.com", "TempPass==")));
+        mapper.GetAdminCreateUserResult(Arg.Any<AuthResult<AdminCreatedUser>>())
+            .Returns(Results.Created("/", null as AdminCreatedUserResponse));
+
+        await AdminEndpoints.CreateUserAsync(ValidRequest, auth, mapper, CancellationToken.None);
+
+        await auth.Received(1).AdminCreateUserAsync(
+            ValidRequest.Username, ValidRequest.Email, Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
@@ -447,4 +447,57 @@ public sealed class AuthResponseMapperTests
 
         act.Should().Throw<System.Diagnostics.UnreachableException>();
     }
+
+    // ==========================================================================
+    // GetAdminCreateUserResult
+    // ==========================================================================
+
+    [Fact]
+    public void GetAdminCreateUserResult_Success_Returns201WithLocationAndBody()
+    {
+        var userId = Guid.NewGuid();
+        var created = new AdminCreatedUser(userId, "alice", "alice@example.com", "TempPass==");
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminCreateUserResult(AuthResult.Ok(created));
+
+        var ok = result.Should()
+            .BeOfType<Microsoft.AspNetCore.Http.HttpResults.Created<AdminCreatedUserResponse>>().Subject;
+        ok.StatusCode.Should().Be(201);
+        ok.Location.Should().Contain(userId.ToString());
+        ok.Value.Should().Be(new AdminCreatedUserResponse(userId, "alice", "alice@example.com", "TempPass=="));
+    }
+
+    [Theory]
+    [InlineData(AuthError.UsernameTaken, 409)]
+    [InlineData(AuthError.EmailTaken, 409)]
+    public void GetAdminCreateUserResult_Failure_ReturnsExpectedStatusCode(AuthError error, int expectedStatus)
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminCreateUserResult(AuthResult.Fail<AdminCreatedUser>(error));
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>()
+            .Which.StatusCode.Should().Be(expectedStatus);
+    }
+
+    [Fact]
+    public void GetAdminCreateUserResult_ErrorFromOtherContext_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetAdminCreateUserResult(AuthResult.Fail<AdminCreatedUser>(AuthError.InvalidCredentials));
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
+
+    [Fact]
+    public void GetAdminCreateUserResult_UndefinedAuthError_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetAdminCreateUserResult(AuthResult.Fail<AdminCreatedUser>((AuthError)999));
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
 }

--- a/src/Anichron.API.Tests.Unit/Security/JwtFactoryTests.cs
+++ b/src/Anichron.API.Tests.Unit/Security/JwtFactoryTests.cs
@@ -155,6 +155,29 @@ public sealed class JwtFactoryTests
     }
 
     [Fact]
+    public void Create_AdminUser_IncludesIsAdminClaim()
+    {
+        var user = new User { Id = Guid.NewGuid(), Username = "alice", IsAdmin = true };
+        var testee = new TestFixture().CreateTestee();
+
+        var jwt = Decode(testee.Create(user));
+
+        jwt.Claims.FirstOrDefault(c => c.Type == "is_admin")?.Value
+            .Should().Be("true");
+    }
+
+    [Fact]
+    public void Create_NonAdminUser_DoesNotIncludeIsAdminClaim()
+    {
+        var user = new User { Id = Guid.NewGuid(), Username = "alice", IsAdmin = false };
+        var testee = new TestFixture().CreateTestee();
+
+        var jwt = Decode(testee.Create(user));
+
+        jwt.Claims.Should().NotContain(c => c.Type == "is_admin");
+    }
+
+    [Fact]
     public void Create_ValidUser_TokenSignatureValidatesWithConfiguredSecret()
     {
         var user = new User { Id = Guid.NewGuid(), Username = "alice" };

--- a/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
@@ -12,7 +12,7 @@ public sealed class AuthServiceTests
 {
     private sealed class TestFixture
     {
-        private readonly IUserRepository _users = Substitute.For<IUserRepository>();
+        internal readonly IUserRepository Users = Substitute.For<IUserRepository>();
         private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
         private readonly IClock _clock = Substitute.For<IClock>();
         private readonly IGuidFactory _guidFactory = Substitute.For<IGuidFactory>();
@@ -44,25 +44,25 @@ public sealed class AuthServiceTests
 
         public TestFixture WithUser(User user)
         {
-            _users.FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(user);
+            Users.FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(user);
             return this;
         }
 
         public TestFixture WithUsernameExists()
         {
-            _users.AnyByUsernameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+            Users.AnyByUsernameAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
             return this;
         }
 
         public TestFixture WithEmailExists()
         {
-            _users.AnyByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+            Users.AnyByEmailAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
             return this;
         }
 
         public TestFixture WithNormalizedUsernameExists(string normalizedUsername)
         {
-            _users.AnyByUsernameAsync(normalizedUsername, Arg.Any<CancellationToken>()).Returns(true);
+            Users.AnyByUsernameAsync(normalizedUsername, Arg.Any<CancellationToken>()).Returns(true);
             return this;
         }
 
@@ -95,7 +95,7 @@ public sealed class AuthServiceTests
 
         public TestFixture WithUserById(Guid id, User? user)
         {
-            _users.FindByIdAsync(id, Arg.Any<CancellationToken>()).Returns(user);
+            Users.FindByIdAsync(id, Arg.Any<CancellationToken>()).Returns(user);
             return this;
         }
 
@@ -108,7 +108,7 @@ public sealed class AuthServiceTests
         }
 
         public AuthService CreateTestee() => new(
-            _users, _unitOfWork, _clock, _guidFactory, _passwordHasher, _validator, TokenService);
+            Users, _unitOfWork, _clock, _guidFactory, _passwordHasher, _validator, TokenService);
     }
 
     // ConstraintName has no setter in Npgsql 10 — must use the full constructor.
@@ -684,5 +684,115 @@ public sealed class AuthServiceTests
 
         await fixture.TokenService.Received(1)
             .MarkAllSessionsRevokedAsync(userId, Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // AdminCreateUserAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task AdminCreateUserAsync_UsernameTaken_ReturnsUsernameTakenError()
+    {
+        var testee = new TestFixture().WithUsernameExists().CreateTestee();
+
+        var result = await testee.AdminCreateUserAsync("alice", "alice@example.com", CancellationToken.None);
+
+        result.Error.Should().Be(AuthError.UsernameTaken);
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_EmailTaken_ReturnsEmailTakenError()
+    {
+        var testee = new TestFixture().WithEmailExists().CreateTestee();
+
+        var result = await testee.AdminCreateUserAsync("alice", "alice@example.com", CancellationToken.None);
+
+        result.Error.Should().Be(AuthError.EmailTaken);
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_Success_IsSuccessAndTemporaryPasswordNonEmpty()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = await testee.AdminCreateUserAsync("alice", "alice@example.com", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            result.IsSuccess.Should().BeTrue();
+            result.Value!.TemporaryPassword.Should().NotBeNullOrEmpty();
+        });
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_Success_UserAddedWithMustChangePasswordTrue()
+    {
+        User? capturedUser = null;
+        var fixture = new TestFixture();
+        fixture.Users.When(r => r.Add(Arg.Any<User>())).Do(c => capturedUser = c.Arg<User>());
+        var testee = fixture.CreateTestee();
+
+        await testee.AdminCreateUserAsync("alice", "alice@example.com", CancellationToken.None);
+
+        capturedUser.Should().NotBeNull();
+        capturedUser.MustChangePassword.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_Success_NormalizesUsernameAndEmail()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = await testee.AdminCreateUserAsync("  Alice  ", "  Alice@Example.COM  ", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            result.Value!.Username.Should().Be("alice");
+            result.Value.Email.Should().Be("alice@example.com");
+        });
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_DbUniqueViolationOnEmail_ReturnsEmailTakenError()
+    {
+        var testee = new TestFixture()
+            .WithSaveChangesThrows(UniqueViolation("ix_users_email"))
+            .CreateTestee();
+
+        var result = await testee.AdminCreateUserAsync("alice", "alice@example.com", CancellationToken.None);
+
+        result.Error.Should().Be(AuthError.EmailTaken);
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_DbUniqueViolationOnUsername_ReturnsUsernameTakenError()
+    {
+        var testee = new TestFixture()
+            .WithSaveChangesThrows(UniqueViolation("ix_users_username"))
+            .CreateTestee();
+
+        var result = await testee.AdminCreateUserAsync("alice", "alice@example.com", CancellationToken.None);
+
+        result.Error.Should().Be(AuthError.UsernameTaken);
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_NullUsername_ThrowsArgumentNullException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = async () => await testee.AdminCreateUserAsync(null!, "alice@example.com", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("username");
+    }
+
+    [Fact]
+    public async Task AdminCreateUserAsync_NullEmail_ThrowsArgumentNullException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = async () => await testee.AdminCreateUserAsync("alice", null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("email");
     }
 }

--- a/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
@@ -739,6 +739,23 @@ public sealed class AuthServiceTests
     }
 
     [Fact]
+    public async Task AdminCreateUserAsync_Success_PasswordIsHashedBeforeStorage()
+    {
+        User? capturedUser = null;
+        var fixture = new TestFixture();
+        fixture.Users.When(r => r.Add(Arg.Any<User>())).Do(c => capturedUser = c.Arg<User>());
+        var testee = fixture.CreateTestee();
+
+        var result = await testee.AdminCreateUserAsync("alice", "alice@example.com", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            capturedUser!.PasswordHash.Should().Be("hashed_value");
+            capturedUser.PasswordHash.Should().NotBe(result.Value!.TemporaryPassword);
+        });
+    }
+
+    [Fact]
     public async Task AdminCreateUserAsync_Success_NormalizesUsernameAndEmail()
     {
         var testee = new TestFixture().CreateTestee();

--- a/src/Anichron.API/Endpoints/AdminEndpoints.cs
+++ b/src/Anichron.API/Endpoints/AdminEndpoints.cs
@@ -8,7 +8,7 @@ public static class AdminEndpoints
     public static IEndpointRouteBuilder MapAdminEndpoints(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup(ApiPaths.Users.Group).WithTags("Users");
-        group.MapPost("/", CreateUserAsync)
+        group.MapPost(string.Empty, CreateUserAsync)
              .RequireAuthorization(AuthPolicies.Admin);
         return app;
     }

--- a/src/Anichron.API/Endpoints/AdminEndpoints.cs
+++ b/src/Anichron.API/Endpoints/AdminEndpoints.cs
@@ -1,0 +1,28 @@
+using Anichron.API.Infrastructure;
+using Anichron.API.Services;
+
+namespace Anichron.API.Endpoints;
+
+public static class AdminEndpoints
+{
+    public static IEndpointRouteBuilder MapAdminEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup(ApiPaths.Users.Group).WithTags("Users");
+        group.MapPost("/", CreateUserAsync)
+             .RequireAuthorization(AuthPolicies.Admin);
+        return app;
+    }
+
+    internal static async Task<IResult> CreateUserAsync(
+        CreateAdminUserRequest req,
+        IAuthService auth,
+        IAuthResponseMapper mapper,
+        CancellationToken ct)
+    {
+        var result = await auth.AdminCreateUserAsync(req.Username, req.Email, ct);
+        return mapper.GetAdminCreateUserResult(result);
+    }
+}
+
+public sealed record CreateAdminUserRequest(string Username, string Email);
+public sealed record AdminCreatedUserResponse(Guid Id, string Username, string Email, string TemporaryPassword);

--- a/src/Anichron.API/Endpoints/AuthResponseMapper.cs
+++ b/src/Anichron.API/Endpoints/AuthResponseMapper.cs
@@ -12,6 +12,7 @@ public interface IAuthResponseMapper
     IResult GetLoginResult(AuthResult<AuthTokens> result, HttpContext http, bool setCookie);
     IResult GetRefreshResult(AuthResult<AuthTokens> result, HttpContext http, bool setCookie);
     IResult GetChangePasswordResult(AuthResult result, PasswordPolicy passwordPolicy);
+    IResult GetAdminCreateUserResult(AuthResult<AdminCreatedUser> result);
     void ClearRefreshCookie(HttpContext http);
 }
 
@@ -138,6 +139,36 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 => throw new UnreachableException($"Unexpected AuthError in ChangePassword: {result.Error}"),
             _ => throw new UnreachableException($"Unhandled AuthError in ChangePassword: {result.Error}"),
         };
+    }
+
+    public IResult GetAdminCreateUserResult(AuthResult<AdminCreatedUser> result)
+    {
+        if (!result.IsSuccess)
+        {
+            return result.Error switch
+            {
+                AuthError.UsernameTaken => Results.Conflict(new { error = AuthMessages.UsernameTaken }),
+                AuthError.EmailTaken => Results.Conflict(new { error = AuthMessages.EmailTaken }),
+                // Not reachable from AdminCreateUserAsync; signals a logic bug if reached.
+                AuthError.None or
+                AuthError.InvalidCredentials or
+                AuthError.TokenInvalid or
+                AuthError.InvalidUsername or
+                AuthError.InvalidEmail or
+                AuthError.PasswordTooShort or
+                AuthError.PasswordTooLong or
+                AuthError.PasswordPwned or
+                AuthError.AccountDisabled or
+                AuthError.AccountTemporarilyLocked
+                    => throw new UnreachableException($"Unexpected AuthError in AdminCreateUser: {result.Error}"),
+                _ => throw new UnreachableException($"Unhandled AuthError in AdminCreateUser: {result.Error}"),
+            };
+        }
+
+        var created = result.Value!;
+        var location = $"{ApiPaths.Base}/{ApiPaths.Users.Group}/{created.Id}";
+        return Results.Created(location, new AdminCreatedUserResponse(
+            created.Id, created.Username, created.Email, created.TemporaryPassword));
     }
 
     public void ClearRefreshCookie(HttpContext http)

--- a/src/Anichron.API/Infrastructure/AppClaimTypes.cs
+++ b/src/Anichron.API/Infrastructure/AppClaimTypes.cs
@@ -3,4 +3,5 @@ namespace Anichron.API.Infrastructure;
 internal static class AppClaimTypes
 {
     internal const string MustChangePassword = "must_change_password";
+    internal const string IsAdmin = "is_admin";
 }

--- a/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
@@ -15,6 +15,7 @@ public static partial class ApplicationExtensions
             var api = app.MapGroup(ApiPaths.Base);
             api.MapAuthEndpoints();
             api.MapUserEndpoints();
+            api.MapAdminEndpoints();
             return app;
         }
 

--- a/src/Anichron.API/Infrastructure/AuthPolicies.cs
+++ b/src/Anichron.API/Infrastructure/AuthPolicies.cs
@@ -1,0 +1,6 @@
+namespace Anichron.API.Infrastructure;
+
+internal static class AuthPolicies
+{
+    internal const string Admin = "Admin";
+}

--- a/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
@@ -171,5 +171,12 @@ public static class ServiceCollectionExtensions
 
             return services;
         }
+
+        public IServiceCollection AddAuthorizationPolicies()
+        {
+            return services.AddAuthorization(options =>
+                options.AddPolicy(AuthPolicies.Admin,
+                    policy => policy.RequireClaim(AppClaimTypes.IsAdmin, "true")));
+        }
     }
 }

--- a/src/Anichron.API/Program.cs
+++ b/src/Anichron.API/Program.cs
@@ -9,6 +9,7 @@ builder.Services
     .AddForwardedHeadersSupport()
     .AddAuthServices(builder.Configuration)
     .AddAuthorization()
+    .AddAuthorizationPolicies()
     .AddRateLimiting()
     .AddCorsPolicy(builder.Configuration);
 

--- a/src/Anichron.API/Security/JwtFactory.cs
+++ b/src/Anichron.API/Security/JwtFactory.cs
@@ -44,6 +44,9 @@ public sealed class JwtFactory : IJwtFactory
         if (user.MustChangePassword)
             claims.Add(new Claim(AppClaimTypes.MustChangePassword, "true"));
 
+        if (user.IsAdmin)
+            claims.Add(new Claim(AppClaimTypes.IsAdmin, "true"));
+
         var token = new JwtSecurityToken(
             issuer: _settings.Issuer,
             audience: _settings.Audience,

--- a/src/Anichron.API/Services/AuthService.cs
+++ b/src/Anichron.API/Services/AuthService.cs
@@ -5,10 +5,12 @@ using Anichron.Core.Data.Repository;
 using Anichron.Core.Domain;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
+using System.Security.Cryptography;
 
 namespace Anichron.API.Services;
 
 public sealed record AuthTokens(string AccessToken, string RefreshToken);
+public sealed record AdminCreatedUser(Guid Id, string Username, string Email, string TemporaryPassword);
 
 public enum AuthError
 {
@@ -60,6 +62,7 @@ public interface IAuthService
     Task<AuthResult<AuthTokens>> RefreshAsync(string rawToken, CancellationToken ct);
     Task RevokeAsync(string rawToken, CancellationToken ct);
     Task<AuthResult> ChangePasswordAsync(Guid userId, string currentPassword, string newPassword, CancellationToken ct);
+    Task<AuthResult<AdminCreatedUser>> AdminCreateUserAsync(string username, string email, CancellationToken ct);
 }
 
 public sealed class AuthService(
@@ -190,6 +193,47 @@ public sealed class AuthService(
         }, ct);
 
         return AuthResult.Ok();
+    }
+
+    public async Task<AuthResult<AdminCreatedUser>> AdminCreateUserAsync(string username, string email, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(username);
+        ArgumentNullException.ThrowIfNull(email);
+
+        var normalizedUsername = username.Trim().ToLowerInvariant();
+        var normalizedEmail = email.Trim().ToLowerInvariant();
+
+        if (await users.AnyByUsernameAsync(normalizedUsername, ct))
+            return AuthResult.Fail<AdminCreatedUser>(AuthError.UsernameTaken);
+
+        if (await users.AnyByEmailAsync(normalizedEmail, ct))
+            return AuthResult.Fail<AdminCreatedUser>(AuthError.EmailTaken);
+
+        var temporaryPassword = Convert.ToBase64String(RandomNumberGenerator.GetBytes(12));
+
+        var user = new User
+        {
+            Id = guidFactory.NewGuid(),
+            Username = normalizedUsername,
+            Email = normalizedEmail,
+            PasswordHash = passwordHasher.Hash(temporaryPassword),
+            MustChangePassword = true,
+        };
+
+        users.Add(user);
+
+        try
+        {
+            await unitOfWork.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" } pg)
+        {
+            return pg.ConstraintName?.Contains("Email", StringComparison.OrdinalIgnoreCase) == true
+                ? AuthResult.Fail<AdminCreatedUser>(AuthError.EmailTaken)
+                : AuthResult.Fail<AdminCreatedUser>(AuthError.UsernameTaken);
+        }
+
+        return AuthResult.Ok(new AdminCreatedUser(user.Id, user.Username, user.Email, temporaryPassword));
     }
 
     private async Task RecordFailedLoginAttemptAsync(User user, Instant now, CancellationToken ct)


### PR DESCRIPTION
## Summary

Implements issue #99 — an admin-only endpoint to provision new users with a temporary password, without exposing the admin nature of the endpoint in the URL.

- `POST /api/v1/users` — requires `is_admin` JWT claim (enforced by `"Admin"` authorization policy)
- Generates a cryptographically random 16-char base64 temporary password
- Sets `MustChangePassword = true` so the user is forced to change it on first login
- Returns `201 Created` with `{ id, username, email, temporaryPassword }` — the only time the plain-text password is visible
- Returns `409 Conflict` if username or email is already taken
- Normalizes username and email (trim + lowercase) before storage

### Infrastructure additions

- `AppClaimTypes.IsAdmin = "is_admin"` — constant for the admin claim
- `JwtFactory` now emits `is_admin: "true"` for admin users, making `GET /api/v1/users/me` return `isAdmin: true` correctly
- `AuthPolicies.Admin` — named authorization policy requiring the `is_admin` claim
- `ServiceCollectionExtensions.AddAuthorizationPolicies()` — registers the policy; called from `Program.cs`
- Response mapping follows `IAuthResponseMapper` with `GetAdminCreateUserResult` — consistent switch + `UnreachableException` pattern

### Security note

The route `POST /api/v1/users` is intentionally indistinguishable from other user-related routes. Authorization is enforced via the `is_admin` claim, not by URL structure.

## Test plan

- [ ] All 251 existing tests pass
- [ ] `AuthService.AdminCreateUserAsync` — 8 tests: username/email taken, success with normalized credentials, `MustChangePassword = true`, DB unique constraint fallback, null argument guards
- [ ] `AuthResponseMapper.GetAdminCreateUserResult` — 4 tests: 201 with location + body, 409 for each conflict, unreachable/undefined errors throw
- [ ] `AdminEndpoints.CreateUserAsync` — 2 tests: delegates to mapper, passes request values to service

🤖 Generated with [Claude Code](https://claude.com/claude-code)