### PR TITLE
feat(auth): gate registration with invite token and add admin password reset

### DIFF
--- a/src/Anichron.API.Tests.Unit/Endpoints/AdminEndpointsTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AdminEndpointsTests.cs
@@ -45,4 +45,26 @@ public sealed class AdminEndpointsTests
         await auth.Received(1).AdminCreateUserAsync(
             ValidRequest.Username, ValidRequest.Email, Arg.Any<CancellationToken>());
     }
+
+    // ==========================================================================
+    // ResetUserPasswordAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task ResetUserPasswordAsync_CallsServiceWithUserIdAndPassesResultToMapper()
+    {
+        var userId = Guid.NewGuid();
+        var serviceResult = new AdminUserPasswordReset("TempPass==");
+        var expectedResult = Results.Ok(new { temporaryPassword = "TempPass==" });
+        var adminReset = Substitute.For<IAdminResetService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        adminReset.ResetUserPasswordAsync(userId, Arg.Any<CancellationToken>()).Returns(serviceResult);
+        mapper.GetAdminResetPasswordResult(serviceResult).Returns(expectedResult);
+
+        var result = await AdminEndpoints.ResetUserPasswordAsync(userId, adminReset, mapper, CancellationToken.None);
+
+        result.Should().BeSameAs(expectedResult);
+        await adminReset.Received(1).ResetUserPasswordAsync(userId, Arg.Any<CancellationToken>());
+        mapper.Received(1).GetAdminResetPasswordResult(serviceResult);
+    }
 }

--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
@@ -524,8 +524,9 @@ public sealed class AuthResponseMapperTests
 
         var result = testee.GetAdminResetPasswordResult(new AdminUserPasswordReset("TempPass=="));
 
-        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(200);
-        result.Should().BeAssignableTo<IValueHttpResult>()
-            .Which.Value.Should().BeEquivalentTo(new { TemporaryPassword = "TempPass==" });
+        var ok = result.Should()
+            .BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<AdminPasswordResetResponse>>().Subject;
+        ok.StatusCode.Should().Be(200);
+        ok.Value.Should().Be(new AdminPasswordResetResponse("TempPass=="));
     }
 }

--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
@@ -80,6 +80,7 @@ public sealed class AuthResponseMapperTests
     [InlineData(AuthError.PasswordTooShort, 422)]
     [InlineData(AuthError.PasswordTooLong, 422)]
     [InlineData(AuthError.PasswordPwned, 422)]
+    [InlineData(AuthError.InviteTokenInvalid, 422)]
     public async Task GetRegistrationResult_Failure_ReturnsExpectedStatusCode(AuthError error, int expectedStatus)
     {
         var http = NewHttp();
@@ -499,5 +500,32 @@ public sealed class AuthResponseMapperTests
         var act = () => testee.GetAdminCreateUserResult(AuthResult.Fail<AdminCreatedUser>((AuthError)999));
 
         act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
+
+    // ==========================================================================
+    // GetAdminResetPasswordResult
+    // ==========================================================================
+
+    [Fact]
+    public void GetAdminResetPasswordResult_NullResult_Returns404()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminResetPasswordResult(null);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>()
+            .Which.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public void GetAdminResetPasswordResult_Success_Returns200WithTemporaryPassword()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminResetPasswordResult(new AdminUserPasswordReset("TempPass=="));
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(200);
+        result.Should().BeAssignableTo<IValueHttpResult>()
+            .Which.Value.Should().BeEquivalentTo(new { TemporaryPassword = "TempPass==" });
     }
 }

--- a/src/Anichron.API.Tests.Unit/Services/AdminResetServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AdminResetServiceTests.cs
@@ -3,8 +3,6 @@ using Anichron.API.Services;
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Core.Domain;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace Anichron.API.Tests.Unit.Services;
 
@@ -14,152 +12,89 @@ public sealed class AdminResetServiceTests
     {
         public IUserRepository Users { get; } = Substitute.For<IUserRepository>();
         public IUnitOfWork UnitOfWork { get; } = Substitute.For<IUnitOfWork>();
+        private readonly IClock _clock = Substitute.For<IClock>();
         private readonly IPasswordHasher _passwordHasher = Substitute.For<IPasswordHasher>();
-        private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
-        private readonly ILogger<AdminResetService> _logger = Substitute.For<ILogger<AdminResetService>>();
+        internal readonly ITokenService TokenService = Substitute.For<ITokenService>();
 
         public TestFixture()
         {
-            _configuration[Arg.Any<string>()].Returns((string?)null);
             _passwordHasher.Hash(Arg.Any<string>()).Returns("hashed_new_password");
-        }
-
-        public TestFixture WithResetPassword(string password)
-        {
-            _configuration["ADMIN_RESET_PASSWORD"].Returns(password);
-            return this;
-        }
-
-        public TestFixture WithTargetUsername(string username)
-        {
-            _configuration["ADMIN_RESET_USERNAME"].Returns(username);
-            return this;
-        }
-
-        public TestFixture WithAdminByUsername(string username, User? admin)
-        {
-            Users.FindAdminByUsernameAsync(username, Arg.Any<CancellationToken>()).Returns(admin);
-            return this;
-        }
-
-        public TestFixture WithAdmins(List<User> admins)
-        {
-            Users.FindAdminsAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(admins);
-            return this;
+            _clock.GetCurrentInstant().Returns(Instant.FromUtc(2026, 1, 1, 12, 0, 0));
         }
 
         public AdminResetService CreateTestee() => new(
-            Users, UnitOfWork, _passwordHasher, _configuration, _logger);
+            Users, UnitOfWork, _clock, _passwordHasher, TokenService);
     }
 
-    // ==========================================================================
-    // ResetIfRequestedAsync
-    // ==========================================================================
-
     [Fact]
-    public async Task ResetIfRequestedAsync_NoResetPasswordConfigured_ReturnsWithoutAnyDbCalls()
+    public async Task ResetUserPasswordAsync_UserNotFound_ReturnsNull()
     {
+        var userId = Guid.NewGuid();
         var fixture = new TestFixture();
+        fixture.Users.FindByIdAsync(userId, Arg.Any<CancellationToken>()).Returns((User?)null);
         var testee = fixture.CreateTestee();
 
-        await testee.ResetIfRequestedAsync(CancellationToken.None);
+        var result = await testee.ResetUserPasswordAsync(userId, CancellationToken.None);
 
-        fixture.Users.DidNotReceive().Add(Arg.Any<User>());
-        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        result.Should().BeNull();
     }
 
     [Fact]
-    public async Task ResetIfRequestedAsync_TargetUsernameSet_AdminFound_ResetsPasswordAndSaves()
+    public async Task ResetUserPasswordAsync_UserFound_ReturnsNonEmptyTemporaryPassword()
     {
-        var admin = new User { Username = "alice", MustChangePassword = false };
-        var fixture = new TestFixture()
-            .WithResetPassword("new_password")
-            .WithTargetUsername("alice")
-            .WithAdminByUsername("alice", admin);
+        var user = new User { Id = Guid.NewGuid() };
+        var fixture = new TestFixture();
+        fixture.Users.FindByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
         var testee = fixture.CreateTestee();
 
-        await testee.ResetIfRequestedAsync(CancellationToken.None);
+        var result = await testee.ResetUserPasswordAsync(user.Id, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.TemporaryPassword.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task ResetUserPasswordAsync_UserFound_SetsMustChangePasswordAndHashesPassword()
+    {
+        var user = new User { Id = Guid.NewGuid(), MustChangePassword = false };
+        var fixture = new TestFixture();
+        fixture.Users.FindByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        var testee = fixture.CreateTestee();
+
+        var result = await testee.ResetUserPasswordAsync(user.Id, CancellationToken.None);
 
         Assert.Multiple(() =>
         {
-            admin.PasswordHash.Should().Be("hashed_new_password");
-            admin.MustChangePassword.Should().BeTrue();
+            user.MustChangePassword.Should().BeTrue();
+            user.PasswordHash.Should().Be("hashed_new_password");
+            user.PasswordHash.Should().NotBe(result!.TemporaryPassword);
         });
-        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ResetIfRequestedAsync_TargetUsernameSet_AdminNotFound_DoesNotSave()
+    public async Task ResetUserPasswordAsync_UserFound_RevokesAllTokens()
     {
-        var fixture = new TestFixture()
-            .WithResetPassword("new_password")
-            .WithTargetUsername("ghost")
-            .WithAdminByUsername("ghost", null);
+        var user = new User { Id = Guid.NewGuid() };
+        var fixture = new TestFixture();
+        fixture.Users.FindByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
         var testee = fixture.CreateTestee();
 
-        await testee.ResetIfRequestedAsync(CancellationToken.None);
+        await testee.ResetUserPasswordAsync(user.Id, CancellationToken.None);
 
-        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        await fixture.TokenService.Received(1)
+            .MarkAllSessionsRevokedAsync(user.Id, Arg.Any<Instant>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ResetIfRequestedAsync_TargetUsernameSet_NormalizesBeforeLookup()
+    public async Task ResetUserPasswordAsync_UserFound_SavesChanges()
     {
-        var admin = new User { Username = "alice" };
-        var fixture = new TestFixture()
-            .WithResetPassword("new_password")
-            .WithTargetUsername("  ALICE  ")
-            .WithAdminByUsername("alice", admin);
+        var user = new User { Id = Guid.NewGuid() };
+        var fixture = new TestFixture();
+        fixture.Users.FindByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
         var testee = fixture.CreateTestee();
 
-        await testee.ResetIfRequestedAsync(CancellationToken.None);
+        await testee.ResetUserPasswordAsync(user.Id, CancellationToken.None);
 
-        await fixture.Users.Received(1)
-            .FindAdminByUsernameAsync("alice", Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ResetIfRequestedAsync_NoTargetUsername_NoAdmins_DoesNotSave()
-    {
-        var fixture = new TestFixture()
-            .WithResetPassword("new_password")
-            .WithAdmins([]);
-        var testee = fixture.CreateTestee();
-
-        await testee.ResetIfRequestedAsync(CancellationToken.None);
-
-        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ResetIfRequestedAsync_NoTargetUsername_MultipleAdmins_DoesNotSave()
-    {
-        var fixture = new TestFixture()
-            .WithResetPassword("new_password")
-            .WithAdmins([new User(), new User()]);
-        var testee = fixture.CreateTestee();
-
-        await testee.ResetIfRequestedAsync(CancellationToken.None);
-
-        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ResetIfRequestedAsync_NoTargetUsername_SingleAdmin_ResetsPasswordAndSaves()
-    {
-        var admin = new User { Username = "admin", MustChangePassword = false };
-        var fixture = new TestFixture()
-            .WithResetPassword("new_password")
-            .WithAdmins([admin]);
-        var testee = fixture.CreateTestee();
-
-        await testee.ResetIfRequestedAsync(CancellationToken.None);
-
-        Assert.Multiple(() =>
-        {
-            admin.PasswordHash.Should().Be("hashed_new_password");
-            admin.MustChangePassword.Should().BeTrue();
-        });
         await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/src/Anichron.API.Tests.Unit/Services/AdminResetServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AdminResetServiceTests.cs
@@ -20,6 +20,9 @@ public sealed class AdminResetServiceTests
         {
             _passwordHasher.Hash(Arg.Any<string>()).Returns("hashed_new_password");
             _clock.GetCurrentInstant().Returns(Instant.FromUtc(2026, 1, 1, 12, 0, 0));
+            UnitOfWork
+                .ExecuteInTransactionAsync(Arg.Any<Func<Task>>(), Arg.Any<CancellationToken>())
+                .Returns(callInfo => callInfo.Arg<Func<Task>>()());
         }
 
         public AdminResetService CreateTestee() => new(
@@ -96,5 +99,25 @@ public sealed class AdminResetServiceTests
         await testee.ResetUserPasswordAsync(user.Id, CancellationToken.None);
 
         await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetUserPasswordAsync_UserFound_RevokesTokensBeforeSavingChanges()
+    {
+        var user = new User { Id = Guid.NewGuid() };
+        var fixture = new TestFixture();
+        fixture.Users.FindByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+        var callOrder = new List<string>();
+        fixture.TokenService
+            .When(t => t.MarkAllSessionsRevokedAsync(Arg.Any<Guid>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>()))
+            .Do(_ => callOrder.Add("revoke"));
+        fixture.UnitOfWork
+            .When(u => u.SaveChangesAsync(Arg.Any<CancellationToken>()))
+            .Do(_ => callOrder.Add("save"));
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetUserPasswordAsync(user.Id, CancellationToken.None);
+
+        callOrder.Should().Equal("revoke", "save");
     }
 }

--- a/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
@@ -351,8 +351,32 @@ public sealed class AuthServiceTests
         Assert.Multiple(() =>
         {
             invite.UsedAt.Should().NotBeNull();
-            invite.UsedByUserId.Should().NotBeNull();
+            // GuidFactory mock returns Guid.Empty — verifies the FK points to the registered user.
+            invite.UsedByUserId.Should().Be(Guid.Empty);
         });
+    }
+
+    [Fact]
+    public async Task RegisterAsync_EmptyInviteToken_ReturnsInviteTokenInvalid()
+    {
+        var testee = new TestFixture().WithNoValidInvite().CreateTestee();
+
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", string.Empty, CancellationToken.None);
+
+        result.Error.Should().Be(AuthError.InviteTokenInvalid);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ConcurrentInviteRace_ReturnsInviteTokenInvalid()
+    {
+        // Simulates xmin concurrency conflict: two requests race to consume the same invite.
+        var fixture = new TestFixture()
+            .WithSaveChangesThrows(new DbUpdateConcurrencyException("concurrency conflict", (Exception?)null));
+        var testee = fixture.CreateTestee();
+
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
+
+        result.Error.Should().Be(AuthError.InviteTokenInvalid);
     }
 
     // ==========================================================================

--- a/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AuthServiceTests.cs
@@ -13,6 +13,7 @@ public sealed class AuthServiceTests
     private sealed class TestFixture
     {
         internal readonly IUserRepository Users = Substitute.For<IUserRepository>();
+        private readonly IInviteRepository _invites = Substitute.For<IInviteRepository>();
         private readonly IUnitOfWork _unitOfWork = Substitute.For<IUnitOfWork>();
         private readonly IClock _clock = Substitute.For<IClock>();
         private readonly IGuidFactory _guidFactory = Substitute.For<IGuidFactory>();
@@ -34,6 +35,23 @@ public sealed class AuthServiceTests
             _unitOfWork
                 .ExecuteInTransactionAsync(Arg.Any<Func<Task>>(), Arg.Any<CancellationToken>())
                 .Returns(callInfo => callInfo.Arg<Func<Task>>()());
+            // Default: return a valid invite so existing register tests are unaffected
+            _invites.FindValidByHashAsync(Arg.Any<string>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>())
+                .Returns(new Invite { Id = Guid.NewGuid(), CreatedByUserId = Guid.NewGuid() });
+        }
+
+        public TestFixture WithNoValidInvite()
+        {
+            _invites.FindValidByHashAsync(Arg.Any<string>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>())
+                .Returns((Invite?)null);
+            return this;
+        }
+
+        public TestFixture WithValidInvite(Invite invite)
+        {
+            _invites.FindValidByHashAsync(Arg.Any<string>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>())
+                .Returns(invite);
+            return this;
         }
 
         public TestFixture WithPasswordValid()
@@ -108,7 +126,7 @@ public sealed class AuthServiceTests
         }
 
         public AuthService CreateTestee() => new(
-            Users, _unitOfWork, _clock, _guidFactory, _passwordHasher, _validator, TokenService);
+            Users, _invites, _unitOfWork, _clock, _guidFactory, _passwordHasher, _validator, TokenService);
     }
 
     // ConstraintName has no setter in Npgsql 10 — must use the full constructor.
@@ -129,7 +147,7 @@ public sealed class AuthServiceTests
             .WithTokenIssued(new AuthTokens("acc", "ref"));
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -144,7 +162,7 @@ public sealed class AuthServiceTests
     {
         var testee = new TestFixture().CreateTestee();
 
-        var act = async () => await testee.RegisterAsync(null!, "alice@example.com", "password", CancellationToken.None);
+        var act = async () => await testee.RegisterAsync(null!, "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("username");
     }
@@ -154,7 +172,7 @@ public sealed class AuthServiceTests
     {
         var testee = new TestFixture().CreateTestee();
 
-        var act = async () => await testee.RegisterAsync("alice", null!, "password", CancellationToken.None);
+        var act = async () => await testee.RegisterAsync("alice", null!, "password", "invite_token", CancellationToken.None);
 
         await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("email");
     }
@@ -164,7 +182,7 @@ public sealed class AuthServiceTests
     {
         var testee = new TestFixture().CreateTestee();
 
-        var act = async () => await testee.RegisterAsync("alice", "alice@example.com", null!, CancellationToken.None);
+        var act = async () => await testee.RegisterAsync("alice", "alice@example.com", null!, "invite_token", CancellationToken.None);
 
         await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("password");
     }
@@ -181,7 +199,7 @@ public sealed class AuthServiceTests
             .WithValidationError(validationError);
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -197,7 +215,7 @@ public sealed class AuthServiceTests
             .WithUsernameExists();
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -213,7 +231,7 @@ public sealed class AuthServiceTests
             .WithEmailExists();
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -229,7 +247,7 @@ public sealed class AuthServiceTests
             .WithSaveChangesThrows(UniqueViolation("ix_users_email_unique"));
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -245,7 +263,7 @@ public sealed class AuthServiceTests
             .WithSaveChangesThrows(UniqueViolation("ix_users_username_unique"));
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -261,7 +279,7 @@ public sealed class AuthServiceTests
             .WithSaveChangesThrows(UniqueViolation(null));
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         Assert.Multiple(() =>
         {
@@ -279,9 +297,62 @@ public sealed class AuthServiceTests
             .WithNormalizedUsernameExists("alice");
         var testee = fixture.CreateTestee();
 
-        var result = await testee.RegisterAsync("  ALICE  ", "alice@example.com", "password", CancellationToken.None);
+        var result = await testee.RegisterAsync("  ALICE  ", "alice@example.com", "password", "invite_token", CancellationToken.None);
 
         result.Error.Should().Be(AuthError.UsernameTaken);
+    }
+
+    [Fact]
+    public void HashInviteToken_SameInput_ProducesSameHash()
+    {
+        var hash1 = AuthService.HashInviteToken("my-token");
+        var hash2 = AuthService.HashInviteToken("my-token");
+
+        hash1.Should().Be(hash2);
+    }
+
+    [Fact]
+    public void HashInviteToken_DifferentInputs_ProduceDifferentHashes()
+    {
+        var hash1 = AuthService.HashInviteToken("token-a");
+        var hash2 = AuthService.HashInviteToken("token-b");
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_InvalidInviteToken_ReturnsInviteTokenInvalid()
+    {
+        var testee = new TestFixture().WithNoValidInvite().CreateTestee();
+
+        var result = await testee.RegisterAsync("alice", "alice@example.com", "password", "bad_token", CancellationToken.None);
+
+        result.Error.Should().Be(AuthError.InviteTokenInvalid);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_NullInviteToken_ThrowsArgumentNullException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = async () => await testee.RegisterAsync("alice", "alice@example.com", "password", null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>().WithParameterName("inviteToken");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ValidInviteToken_MarksInviteAsUsed()
+    {
+        var invite = new Invite { Id = Guid.NewGuid(), CreatedByUserId = Guid.NewGuid() };
+        var testee = new TestFixture().WithValidInvite(invite).CreateTestee();
+
+        await testee.RegisterAsync("alice", "alice@example.com", "password", "invite_token", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            invite.UsedAt.Should().NotBeNull();
+            invite.UsedByUserId.Should().NotBeNull();
+        });
     }
 
     // ==========================================================================

--- a/src/Anichron.API.Tests.Unit/Services/BootstrapResetServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/BootstrapResetServiceTests.cs
@@ -1,0 +1,161 @@
+using Anichron.API.Security;
+using Anichron.API.Services;
+using Anichron.Core.Data;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Anichron.API.Tests.Unit.Services;
+
+public sealed class BootstrapResetServiceTests
+{
+    private sealed class TestFixture
+    {
+        public IUserRepository Users { get; } = Substitute.For<IUserRepository>();
+        public IUnitOfWork UnitOfWork { get; } = Substitute.For<IUnitOfWork>();
+        private readonly IPasswordHasher _passwordHasher = Substitute.For<IPasswordHasher>();
+        private readonly IConfiguration _configuration = Substitute.For<IConfiguration>();
+        private readonly ILogger<BootstrapResetService> _logger = Substitute.For<ILogger<BootstrapResetService>>();
+
+        public TestFixture()
+        {
+            _configuration[Arg.Any<string>()].Returns((string?)null);
+            _passwordHasher.Hash(Arg.Any<string>()).Returns("hashed_new_password");
+        }
+
+        public TestFixture WithResetPassword(string password)
+        {
+            _configuration["ADMIN_RESET_PASSWORD"].Returns(password);
+            return this;
+        }
+
+        public TestFixture WithTargetUsername(string username)
+        {
+            _configuration["ADMIN_RESET_USERNAME"].Returns(username);
+            return this;
+        }
+
+        public TestFixture WithAdminByUsername(string username, User? admin)
+        {
+            Users.FindAdminByUsernameAsync(username, Arg.Any<CancellationToken>()).Returns(admin);
+            return this;
+        }
+
+        public TestFixture WithAdmins(List<User> admins)
+        {
+            Users.FindAdminsAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(admins);
+            return this;
+        }
+
+        public BootstrapResetService CreateTestee() => new(
+            Users, UnitOfWork, _passwordHasher, _configuration, _logger);
+    }
+
+    [Fact]
+    public async Task ResetIfRequestedAsync_NoResetPasswordConfigured_ReturnsWithoutAnyDbCalls()
+    {
+        var fixture = new TestFixture();
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetIfRequestedAsync(CancellationToken.None);
+
+        fixture.Users.DidNotReceive().Add(Arg.Any<User>());
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetIfRequestedAsync_TargetUsernameSet_AdminFound_ResetsPasswordAndSaves()
+    {
+        var admin = new User { Username = "alice", MustChangePassword = false };
+        var fixture = new TestFixture()
+            .WithResetPassword("new_password")
+            .WithTargetUsername("alice")
+            .WithAdminByUsername("alice", admin);
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetIfRequestedAsync(CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            admin.PasswordHash.Should().Be("hashed_new_password");
+            admin.MustChangePassword.Should().BeTrue();
+        });
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetIfRequestedAsync_TargetUsernameSet_AdminNotFound_DoesNotSave()
+    {
+        var fixture = new TestFixture()
+            .WithResetPassword("new_password")
+            .WithTargetUsername("ghost")
+            .WithAdminByUsername("ghost", null);
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetIfRequestedAsync(CancellationToken.None);
+
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetIfRequestedAsync_TargetUsernameSet_NormalizesBeforeLookup()
+    {
+        var admin = new User { Username = "alice" };
+        var fixture = new TestFixture()
+            .WithResetPassword("new_password")
+            .WithTargetUsername("  ALICE  ")
+            .WithAdminByUsername("alice", admin);
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetIfRequestedAsync(CancellationToken.None);
+
+        await fixture.Users.Received(1)
+            .FindAdminByUsernameAsync("alice", Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetIfRequestedAsync_NoTargetUsername_NoAdmins_DoesNotSave()
+    {
+        var fixture = new TestFixture()
+            .WithResetPassword("new_password")
+            .WithAdmins([]);
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetIfRequestedAsync(CancellationToken.None);
+
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetIfRequestedAsync_NoTargetUsername_MultipleAdmins_DoesNotSave()
+    {
+        var fixture = new TestFixture()
+            .WithResetPassword("new_password")
+            .WithAdmins([new User(), new User()]);
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetIfRequestedAsync(CancellationToken.None);
+
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResetIfRequestedAsync_NoTargetUsername_SingleAdmin_ResetsPasswordAndSaves()
+    {
+        var admin = new User { Username = "admin", MustChangePassword = false };
+        var fixture = new TestFixture()
+            .WithResetPassword("new_password")
+            .WithAdmins([admin]);
+        var testee = fixture.CreateTestee();
+
+        await testee.ResetIfRequestedAsync(CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            admin.PasswordHash.Should().Be("hashed_new_password");
+            admin.MustChangePassword.Should().BeTrue();
+        });
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Anichron.API/Endpoints/AdminEndpoints.cs
+++ b/src/Anichron.API/Endpoints/AdminEndpoints.cs
@@ -7,9 +7,10 @@ public static class AdminEndpoints
 {
     public static IEndpointRouteBuilder MapAdminEndpoints(this IEndpointRouteBuilder app)
     {
-        var group = app.MapGroup(ApiPaths.Users.Group).WithTags("Users");
-        group.MapPost(string.Empty, CreateUserAsync)
-             .RequireAuthorization(AuthPolicies.Admin);
+        var group = app.MapGroup(ApiPaths.Users.Group).WithTags("Users")
+                       .RequireAuthorization(AuthPolicies.Admin);
+        group.MapPost(string.Empty, CreateUserAsync);
+        group.MapPost("{userId:guid}/password-reset", ResetUserPasswordAsync);
         return app;
     }
 
@@ -21,6 +22,16 @@ public static class AdminEndpoints
     {
         var result = await auth.AdminCreateUserAsync(req.Username, req.Email, ct);
         return mapper.GetAdminCreateUserResult(result);
+    }
+
+    internal static async Task<IResult> ResetUserPasswordAsync(
+        Guid userId,
+        IAdminResetService adminReset,
+        IAuthResponseMapper mapper,
+        CancellationToken ct)
+    {
+        var result = await adminReset.ResetUserPasswordAsync(userId, ct);
+        return mapper.GetAdminResetPasswordResult(result);
     }
 }
 

--- a/src/Anichron.API/Endpoints/AdminEndpoints.cs
+++ b/src/Anichron.API/Endpoints/AdminEndpoints.cs
@@ -9,8 +9,10 @@ public static class AdminEndpoints
     {
         var group = app.MapGroup(ApiPaths.Users.Group).WithTags("Users")
                        .RequireAuthorization(AuthPolicies.Admin);
-        group.MapPost(string.Empty, CreateUserAsync);
-        group.MapPost("{userId:guid}/password-reset", ResetUserPasswordAsync);
+        group.MapPost(string.Empty, CreateUserAsync)
+             .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapPost("{userId:guid}/password-reset", ResetUserPasswordAsync)
+             .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
         return app;
     }
 
@@ -37,3 +39,4 @@ public static class AdminEndpoints
 
 public sealed record CreateAdminUserRequest(string Username, string Email);
 public sealed record AdminCreatedUserResponse(Guid Id, string Username, string Email, string TemporaryPassword);
+public sealed record AdminPasswordResetResponse(string TemporaryPassword);

--- a/src/Anichron.API/Endpoints/AuthEndpoints.cs
+++ b/src/Anichron.API/Endpoints/AuthEndpoints.cs
@@ -32,7 +32,7 @@ public static class AuthEndpoints
         IOptions<UsernamePolicy> usernamePolicy,
         CancellationToken ct)
     {
-        var result = await auth.RegisterAsync(req.Username, req.Email, req.Password, ct);
+        var result = await auth.RegisterAsync(req.Username, req.Email, req.Password, req.InviteToken, ct);
         return mapper.GetRegistrationResult(result, http, passwordPolicy.Value, usernamePolicy.Value);
     }
 
@@ -89,6 +89,6 @@ public static class AuthEndpoints
     private static IResult PasswordResetConfirm() => Results.StatusCode(StatusCodes.Status501NotImplemented);
 }
 
-public sealed record RegisterRequest(string Username, string Email, string Password);
+public sealed record RegisterRequest(string Username, string Email, string Password, string InviteToken);
 public sealed record LoginRequest(string UsernameOrEmail, string Password);
 public sealed record RefreshRequest(string RefreshToken);

--- a/src/Anichron.API/Endpoints/AuthResponseMapper.cs
+++ b/src/Anichron.API/Endpoints/AuthResponseMapper.cs
@@ -13,6 +13,7 @@ public interface IAuthResponseMapper
     IResult GetRefreshResult(AuthResult<AuthTokens> result, HttpContext http, bool setCookie);
     IResult GetChangePasswordResult(AuthResult result, PasswordPolicy passwordPolicy);
     IResult GetAdminCreateUserResult(AuthResult<AdminCreatedUser> result);
+    IResult GetAdminResetPasswordResult(AdminUserPasswordReset? result);
     void ClearRefreshCookie(HttpContext http);
 }
 
@@ -31,6 +32,7 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.PasswordTooShort => Results.UnprocessableEntity(new { error = passwordPolicy.TooShortMessage }),
                 AuthError.PasswordTooLong => Results.UnprocessableEntity(new { error = passwordPolicy.TooLongMessage }),
                 AuthError.PasswordPwned => Results.UnprocessableEntity(new { error = AuthMessages.PasswordPwned }),
+                AuthError.InviteTokenInvalid => Results.UnprocessableEntity(new { error = AuthMessages.InviteTokenInvalid }),
                 // Not reachable from RegisterAsync; signals a logic bug if reached.
                 AuthError.None or
                 AuthError.InvalidCredentials or
@@ -68,7 +70,8 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.InvalidEmail or
                 AuthError.PasswordTooShort or
                 AuthError.PasswordTooLong or
-                AuthError.PasswordPwned
+                AuthError.PasswordPwned or
+                AuthError.InviteTokenInvalid
                     => throw new UnreachableException($"Unexpected AuthError in Login: {result.Error}"),
                 _ => throw new UnreachableException($"Unhandled AuthError in Login: {result.Error}"),
             };
@@ -99,7 +102,8 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.InvalidEmail or
                 AuthError.PasswordTooShort or
                 AuthError.PasswordTooLong or
-                AuthError.PasswordPwned
+                AuthError.PasswordPwned or
+                AuthError.InviteTokenInvalid
                     => throw new UnreachableException($"Unexpected AuthError in Refresh: {result.Error}"),
                 _ => throw new UnreachableException($"Unhandled AuthError in Refresh: {result.Error}"),
             };
@@ -135,7 +139,8 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
             AuthError.InvalidUsername or
             AuthError.InvalidEmail or
             AuthError.AccountDisabled or
-            AuthError.AccountTemporarilyLocked
+            AuthError.AccountTemporarilyLocked or
+            AuthError.InviteTokenInvalid
                 => throw new UnreachableException($"Unexpected AuthError in ChangePassword: {result.Error}"),
             _ => throw new UnreachableException($"Unhandled AuthError in ChangePassword: {result.Error}"),
         };
@@ -159,7 +164,8 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.PasswordTooLong or
                 AuthError.PasswordPwned or
                 AuthError.AccountDisabled or
-                AuthError.AccountTemporarilyLocked
+                AuthError.AccountTemporarilyLocked or
+                AuthError.InviteTokenInvalid
                     => throw new UnreachableException($"Unexpected AuthError in AdminCreateUser: {result.Error}"),
                 _ => throw new UnreachableException($"Unhandled AuthError in AdminCreateUser: {result.Error}"),
             };
@@ -170,6 +176,11 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
         return Results.Created(location, new AdminCreatedUserResponse(
             created.Id, created.Username, created.Email, created.TemporaryPassword));
     }
+
+    public IResult GetAdminResetPasswordResult(AdminUserPasswordReset? result)
+        => result is null
+            ? Results.NotFound()
+            : Results.Ok(new { result.TemporaryPassword });
 
     public void ClearRefreshCookie(HttpContext http)
         => http.Response.Cookies.Delete(AuthMessages.RefreshTokenCookieName);

--- a/src/Anichron.API/Endpoints/AuthResponseMapper.cs
+++ b/src/Anichron.API/Endpoints/AuthResponseMapper.cs
@@ -180,7 +180,7 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
     public IResult GetAdminResetPasswordResult(AdminUserPasswordReset? result)
         => result is null
             ? Results.NotFound()
-            : Results.Ok(new { result.TemporaryPassword });
+            : Results.Ok(new AdminPasswordResetResponse(result.TemporaryPassword));
 
     public void ClearRefreshCookie(HttpContext http)
         => http.Response.Cookies.Delete(AuthMessages.RefreshTokenCookieName);

--- a/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
@@ -38,7 +38,7 @@ public static partial class ApplicationExtensions
                     var bootstrapSeeder = scope.ServiceProvider.GetRequiredService<IBootstrapSeeder>();
                     await bootstrapSeeder.SeedAsync(ct);
 
-                    var adminResetService = scope.ServiceProvider.GetRequiredService<IAdminResetService>();
+                    var adminResetService = scope.ServiceProvider.GetRequiredService<IBootstrapResetService>();
                     await adminResetService.ResetIfRequestedAsync(ct);
                     return;
                 }

--- a/src/Anichron.API/Infrastructure/AuthMessages.cs
+++ b/src/Anichron.API/Infrastructure/AuthMessages.cs
@@ -15,6 +15,7 @@ internal static class AuthMessages
     internal const string RefreshTokenInvalid = "Refresh token is invalid or has expired.";
     internal const string TooManyRequests = "Too many requests. Please try again later.";
     internal const string RefreshTokenCookieName = "refresh_token";
+    internal const string InviteTokenInvalid = "The invite token is invalid, expired, or has already been used.";
 }
 
 internal static class AuthRateLimitPolicies

--- a/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
@@ -126,7 +126,7 @@ public static class ServiceCollectionExtensions
             services.AddScoped<ITokenService, TokenService>();
             services.AddScoped<IAuthService, AuthService>();
             services.AddTransient<IBootstrapSeeder, BootstrapSeeder>();
-            services.AddTransient<IAdminResetService, AdminResetService>();
+            services.AddScoped<IAdminResetService, AdminResetService>();
             services.AddTransient<IBootstrapResetService, BootstrapResetService>();
 
             // SameSite=None is required when the UI and API are on different origins so browsers

--- a/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
@@ -119,6 +119,7 @@ public static class ServiceCollectionExtensions
             services.AddSingleton<IAuthResponseMapper, AuthResponseMapper>();
             services.AddScoped<IUserRepository, EfUserRepository>();
             services.AddScoped<IRefreshTokenRepository, EfRefreshTokenRepository>();
+            services.AddScoped<IInviteRepository, EfInviteRepository>();
             // AnichronDbContext is already scoped via AddDbContext; reuse the same instance for IUnitOfWork
             services.AddScoped<IUnitOfWork>(sp => sp.GetRequiredService<AnichronDbContext>());
             services.AddScoped<IRegistrationValidator, RegistrationValidator>();
@@ -126,6 +127,7 @@ public static class ServiceCollectionExtensions
             services.AddScoped<IAuthService, AuthService>();
             services.AddTransient<IBootstrapSeeder, BootstrapSeeder>();
             services.AddTransient<IAdminResetService, AdminResetService>();
+            services.AddTransient<IBootstrapResetService, BootstrapResetService>();
 
             // SameSite=None is required when the UI and API are on different origins so browsers
             // send the cookie on cross-origin requests. SameSite=Strict is safer for same-origin.

--- a/src/Anichron.API/Services/AdminResetService.cs
+++ b/src/Anichron.API/Services/AdminResetService.cs
@@ -29,8 +29,12 @@ public sealed class AdminResetService(
         user.PasswordHash = passwordHasher.Hash(temporaryPassword);
         user.MustChangePassword = true;
         var now = clock.GetCurrentInstant();
-        await tokenService.MarkAllSessionsRevokedAsync(userId, now, ct);
-        await unitOfWork.SaveChangesAsync(ct);
+
+        await unitOfWork.ExecuteInTransactionAsync(async () =>
+        {
+            await tokenService.MarkAllSessionsRevokedAsync(userId, now, ct);
+            await unitOfWork.SaveChangesAsync(ct);
+        }, ct);
 
         return new AdminUserPasswordReset(temporaryPassword);
     }

--- a/src/Anichron.API/Services/AdminResetService.cs
+++ b/src/Anichron.API/Services/AdminResetService.cs
@@ -1,75 +1,37 @@
 using Anichron.API.Security;
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
-using Anichron.Core.Domain;
+using System.Security.Cryptography;
 
 namespace Anichron.API.Services;
 
+public sealed record AdminUserPasswordReset(string TemporaryPassword);
+
 public interface IAdminResetService
 {
-    Task ResetIfRequestedAsync(CancellationToken ct);
+    Task<AdminUserPasswordReset?> ResetUserPasswordAsync(Guid userId, CancellationToken ct);
 }
 
-public sealed partial class AdminResetService(
+public sealed class AdminResetService(
     IUserRepository users,
     IUnitOfWork unitOfWork,
+    IClock clock,
     IPasswordHasher passwordHasher,
-    IConfiguration configuration,
-    ILogger<AdminResetService> logger) : IAdminResetService
+    ITokenService tokenService) : IAdminResetService
 {
-    public async Task ResetIfRequestedAsync(CancellationToken ct)
+    public async Task<AdminUserPasswordReset?> ResetUserPasswordAsync(Guid userId, CancellationToken ct)
     {
-        var resetPassword = configuration["ADMIN_RESET_PASSWORD"];
-        if (string.IsNullOrEmpty(resetPassword))
-            return;
+        var user = await users.FindByIdAsync(userId, ct);
+        if (user is null)
+            return null;
 
-        var targetUsername = configuration["ADMIN_RESET_USERNAME"]?.Trim().ToLowerInvariant();
-        User? admin;
-
-        if (!string.IsNullOrEmpty(targetUsername))
-        {
-            admin = await users.FindAdminByUsernameAsync(targetUsername, ct);
-            if (admin is null)
-            {
-                Log.AdminNotFoundByUsername(logger, targetUsername);
-                return;
-            }
-        }
-        else
-        {
-            var admins = await users.FindAdminsAsync(take: 2, ct);
-            switch (admins.Count)
-            {
-                case 0:
-                    Log.NoAdminFound(logger);
-                    return;
-                case > 1:
-                    Log.MultipleAdminsFound(logger);
-                    return;
-                default:
-                    admin = admins[0];
-                    break;
-            }
-        }
-
-        admin.PasswordHash = passwordHasher.Hash(resetPassword);
-        admin.MustChangePassword = true;
+        var temporaryPassword = Convert.ToBase64String(RandomNumberGenerator.GetBytes(12));
+        user.PasswordHash = passwordHasher.Hash(temporaryPassword);
+        user.MustChangePassword = true;
+        var now = clock.GetCurrentInstant();
+        await tokenService.MarkAllSessionsRevokedAsync(userId, now, ct);
         await unitOfWork.SaveChangesAsync(ct);
-        Log.AdminPasswordReset(logger, admin.Username);
-    }
 
-    private static partial class Log
-    {
-        [LoggerMessage(Level = LogLevel.Error, Message = "ADMIN_RESET_PASSWORD is set but no admin with username '{Username}' was found.")]
-        public static partial void AdminNotFoundByUsername(ILogger logger, string username);
-
-        [LoggerMessage(Level = LogLevel.Warning, Message = "ADMIN_RESET_PASSWORD is set but no admin user was found.")]
-        public static partial void NoAdminFound(ILogger logger);
-
-        [LoggerMessage(Level = LogLevel.Error, Message = "ADMIN_RESET_PASSWORD is set but multiple admins exist. Set ADMIN_RESET_USERNAME to specify which admin to reset.")]
-        public static partial void MultipleAdminsFound(ILogger logger);
-
-        [LoggerMessage(Level = LogLevel.Warning, Message = "Admin password has been reset for '{Username}'. Remove ADMIN_RESET_PASSWORD after logging in.")]
-        public static partial void AdminPasswordReset(ILogger logger, string username);
+        return new AdminUserPasswordReset(temporaryPassword);
     }
 }

--- a/src/Anichron.API/Services/AuthService.cs
+++ b/src/Anichron.API/Services/AuthService.cs
@@ -119,7 +119,15 @@ public sealed class AuthService(
 
         try
         {
-            await unitOfWork.SaveChangesAsync(ct);
+            return AuthResult.Ok(await unitOfWork.ExecuteInTransactionAsync(async () =>
+            {
+                await unitOfWork.SaveChangesAsync(ct);
+                return await tokenService.IssueAsync(user, ct);
+            }, ct));
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            return AuthResult.Fail<AuthTokens>(AuthError.InviteTokenInvalid);
         }
         catch (DbUpdateException ex) when (ex.InnerException is PostgresException { SqlState: "23505" } pg)
         {
@@ -127,8 +135,6 @@ public sealed class AuthService(
                 ? AuthResult.Fail<AuthTokens>(AuthError.EmailTaken)
                 : AuthResult.Fail<AuthTokens>(AuthError.UsernameTaken);
         }
-
-        return AuthResult.Ok(await tokenService.IssueAsync(user, ct));
     }
 
     internal static string HashInviteToken(string rawToken)

--- a/src/Anichron.API/Services/AuthService.cs
+++ b/src/Anichron.API/Services/AuthService.cs
@@ -6,6 +6,7 @@ using Anichron.Core.Domain;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
 using System.Security.Cryptography;
+using System.Text;
 
 namespace Anichron.API.Services;
 
@@ -26,6 +27,7 @@ public enum AuthError
     PasswordPwned = 9,
     AccountDisabled = 10,
     AccountTemporarilyLocked = 11,
+    InviteTokenInvalid = 12,
 }
 
 public sealed record AuthResult<T>
@@ -57,7 +59,7 @@ public sealed record AuthResult
 
 public interface IAuthService
 {
-    Task<AuthResult<AuthTokens>> RegisterAsync(string username, string email, string password, CancellationToken ct);
+    Task<AuthResult<AuthTokens>> RegisterAsync(string username, string email, string password, string inviteToken, CancellationToken ct);
     Task<AuthResult<AuthTokens>> LoginAsync(string usernameOrEmail, string password, CancellationToken ct);
     Task<AuthResult<AuthTokens>> RefreshAsync(string rawToken, CancellationToken ct);
     Task RevokeAsync(string rawToken, CancellationToken ct);
@@ -67,6 +69,7 @@ public interface IAuthService
 
 public sealed class AuthService(
     IUserRepository users,
+    IInviteRepository invites,
     IUnitOfWork unitOfWork,
     IClock clock,
     IGuidFactory guidFactory,
@@ -77,11 +80,17 @@ public sealed class AuthService(
 {
     private readonly string _dummyPasswordHash = passwordHasher.Hash(guidFactory.NewGuid().ToString());
 
-    public async Task<AuthResult<AuthTokens>> RegisterAsync(string username, string email, string password, CancellationToken ct)
+    public async Task<AuthResult<AuthTokens>> RegisterAsync(string username, string email, string password, string inviteToken, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(username);
         ArgumentNullException.ThrowIfNull(email);
         ArgumentNullException.ThrowIfNull(password);
+        ArgumentNullException.ThrowIfNull(inviteToken);
+
+        var now = clock.GetCurrentInstant();
+        var invite = await invites.FindValidByHashAsync(HashInviteToken(inviteToken), now, ct);
+        if (invite is null)
+            return AuthResult.Fail<AuthTokens>(AuthError.InviteTokenInvalid);
 
         var normalizedUsername = username.Trim().ToLowerInvariant();
         var normalizedEmail = email.Trim().ToLowerInvariant();
@@ -105,6 +114,8 @@ public sealed class AuthService(
         };
 
         users.Add(user);
+        invite.UsedAt = now;
+        invite.UsedByUserId = user.Id;
 
         try
         {
@@ -119,6 +130,9 @@ public sealed class AuthService(
 
         return AuthResult.Ok(await tokenService.IssueAsync(user, ct));
     }
+
+    internal static string HashInviteToken(string rawToken)
+        => Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
 
     public async Task<AuthResult<AuthTokens>> LoginAsync(string usernameOrEmail, string password, CancellationToken ct)
     {

--- a/src/Anichron.API/Services/BootstrapResetService.cs
+++ b/src/Anichron.API/Services/BootstrapResetService.cs
@@ -1,0 +1,75 @@
+using Anichron.API.Security;
+using Anichron.Core.Data;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+
+namespace Anichron.API.Services;
+
+public interface IBootstrapResetService
+{
+    Task ResetIfRequestedAsync(CancellationToken ct);
+}
+
+public sealed partial class BootstrapResetService(
+    IUserRepository users,
+    IUnitOfWork unitOfWork,
+    IPasswordHasher passwordHasher,
+    IConfiguration configuration,
+    ILogger<BootstrapResetService> logger) : IBootstrapResetService
+{
+    public async Task ResetIfRequestedAsync(CancellationToken ct)
+    {
+        var resetPassword = configuration["ADMIN_RESET_PASSWORD"];
+        if (string.IsNullOrEmpty(resetPassword))
+            return;
+
+        var targetUsername = configuration["ADMIN_RESET_USERNAME"]?.Trim().ToLowerInvariant();
+        User? admin;
+
+        if (!string.IsNullOrEmpty(targetUsername))
+        {
+            admin = await users.FindAdminByUsernameAsync(targetUsername, ct);
+            if (admin is null)
+            {
+                Log.AdminNotFoundByUsername(logger, targetUsername);
+                return;
+            }
+        }
+        else
+        {
+            var admins = await users.FindAdminsAsync(take: 2, ct);
+            switch (admins.Count)
+            {
+                case 0:
+                    Log.NoAdminFound(logger);
+                    return;
+                case > 1:
+                    Log.MultipleAdminsFound(logger);
+                    return;
+                default:
+                    admin = admins[0];
+                    break;
+            }
+        }
+
+        admin.PasswordHash = passwordHasher.Hash(resetPassword);
+        admin.MustChangePassword = true;
+        await unitOfWork.SaveChangesAsync(ct);
+        Log.AdminPasswordReset(logger, admin.Username);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Error, Message = "ADMIN_RESET_PASSWORD is set but no admin with username '{Username}' was found.")]
+        public static partial void AdminNotFoundByUsername(ILogger logger, string username);
+
+        [LoggerMessage(Level = LogLevel.Warning, Message = "ADMIN_RESET_PASSWORD is set but no admin user was found.")]
+        public static partial void NoAdminFound(ILogger logger);
+
+        [LoggerMessage(Level = LogLevel.Error, Message = "ADMIN_RESET_PASSWORD is set but multiple admins exist. Set ADMIN_RESET_USERNAME to specify which admin to reset.")]
+        public static partial void MultipleAdminsFound(ILogger logger);
+
+        [LoggerMessage(Level = LogLevel.Warning, Message = "Admin password has been reset for '{Username}'. Remove ADMIN_RESET_PASSWORD after logging in.")]
+        public static partial void AdminPasswordReset(ILogger logger, string username);
+    }
+}

--- a/src/Anichron.Core/Data/AnichronDbContext.cs
+++ b/src/Anichron.Core/Data/AnichronDbContext.cs
@@ -129,6 +129,14 @@ public class AnichronDbContext(DbContextOptions<AnichronDbContext> options) : Db
         modelBuilder.Entity<Invite>(entity =>
         {
             entity.HasIndex(i => i.TokenHash).IsUnique();
+            entity.Property(i => i.TokenHash).HasMaxLength(44);
+
+            // xmin is a Postgres system column incremented on every UPDATE.
+            // Npgsql recognises the "xmin" column name and excludes it from migrations.
+            entity.Property<uint>("xmin")
+                  .HasColumnName("xmin")
+                  .ValueGeneratedOnAddOrUpdate()
+                  .IsConcurrencyToken();
 
             entity.HasOne(i => i.CreatedBy)
                   .WithMany()

--- a/src/Anichron.Core/Data/AnichronDbContext.cs
+++ b/src/Anichron.Core/Data/AnichronDbContext.cs
@@ -13,6 +13,7 @@ public class AnichronDbContext(DbContextOptions<AnichronDbContext> options) : Db
     public DbSet<Burst> Bursts => Set<Burst>();
     public DbSet<AssetInteraction> Interactions => Set<AssetInteraction>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+    public DbSet<Invite> Invites => Set<Invite>();
 
     public async Task<T> ExecuteInTransactionAsync<T>(Func<Task<T>> action, CancellationToken ct = default)
     {
@@ -123,6 +124,21 @@ public class AnichronDbContext(DbContextOptions<AnichronDbContext> options) : Db
                   .WithMany(u => u.RefreshTokens)
                   .HasForeignKey(r => r.UserId)
                   .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Invite>(entity =>
+        {
+            entity.HasIndex(i => i.TokenHash).IsUnique();
+
+            entity.HasOne(i => i.CreatedBy)
+                  .WithMany()
+                  .HasForeignKey(i => i.CreatedByUserId)
+                  .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasOne(i => i.UsedBy)
+                  .WithMany()
+                  .HasForeignKey(i => i.UsedByUserId)
+                  .OnDelete(DeleteBehavior.SetNull);
         });
 
         modelBuilder.Entity<User>(entity =>

--- a/src/Anichron.Core/Data/Repository/InviteRepository.cs
+++ b/src/Anichron.Core/Data/Repository/InviteRepository.cs
@@ -1,0 +1,20 @@
+using Anichron.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anichron.Core.Data.Repository;
+
+public interface IInviteRepository
+{
+    Task<Invite?> FindValidByHashAsync(string tokenHash, Instant now, CancellationToken ct);
+    void Add(Invite invite);
+}
+
+public sealed class EfInviteRepository(AnichronDbContext db) : IInviteRepository
+{
+    public Task<Invite?> FindValidByHashAsync(string tokenHash, Instant now, CancellationToken ct)
+        => db.Invites.FirstOrDefaultAsync(
+            i => i.TokenHash == tokenHash && i.UsedAt == null && i.ExpiresAt >= now, ct);
+
+    public void Add(Invite invite)
+        => db.Invites.Add(invite);
+}

--- a/src/Anichron.Core/Domain/Invite.cs
+++ b/src/Anichron.Core/Domain/Invite.cs
@@ -1,0 +1,14 @@
+namespace Anichron.Core.Domain;
+
+public class Invite
+{
+    public Guid Id { get; set; }
+    public string TokenHash { get; set; } = string.Empty;
+    public Instant CreatedAt { get; set; }
+    public Instant ExpiresAt { get; set; }
+    public Instant? UsedAt { get; set; }
+    public Guid CreatedByUserId { get; set; }
+    public Guid? UsedByUserId { get; set; }
+    public virtual User CreatedBy { get; set; } = null!;
+    public virtual User? UsedBy { get; set; }
+}

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
@@ -99,13 +99,20 @@ namespace Anichron.Core.Migrations
 
                     b.Property<string>("TokenHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasMaxLength(44)
+                        .HasColumnType("character varying(44)");
 
                     b.Property<Instant?>("UsedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("UsedByUserId")
                         .HasColumnType("uuid");
+
+                    b.Property<uint>("xmin")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
 
                     b.HasKey("Id");
 

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Anichron.Core.Migrations
 {
     [DbContext(typeof(AnichronDbContext))]
-    [Migration("20260507074514_InitialSchema")]
+    [Migration("20260511154104_InitialSchema")]
     partial class InitialSchema
     {
         /// <inheritdoc />
@@ -80,6 +80,43 @@ namespace Anichron.Core.Migrations
                     b.HasIndex("PrimaryAssetId");
 
                     b.ToTable("Bursts");
+                });
+
+            modelBuilder.Entity("Anichron.Core.Domain.Invite", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Instant>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("CreatedByUserId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Instant>("ExpiresAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("TokenHash")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<Instant?>("UsedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("UsedByUserId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedByUserId");
+
+                    b.HasIndex("TokenHash")
+                        .IsUnique();
+
+                    b.HasIndex("UsedByUserId");
+
+                    b.ToTable("Invites");
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.MediaAsset", b =>
@@ -349,6 +386,24 @@ namespace Anichron.Core.Migrations
                         .IsRequired();
 
                     b.Navigation("PrimaryAsset");
+                });
+
+            modelBuilder.Entity("Anichron.Core.Domain.Invite", b =>
+                {
+                    b.HasOne("Anichron.Core.Domain.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedByUserId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("Anichron.Core.Domain.User", "UsedBy")
+                        .WithMany()
+                        .HasForeignKey("UsedByUserId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.Navigation("CreatedBy");
+
+                    b.Navigation("UsedBy");
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.MediaAsset", b =>

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
@@ -32,6 +32,35 @@ namespace Anichron.Core.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "Invites",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    TokenHash = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
+                    UsedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
+                    CreatedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UsedByUserId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Invites", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Invites_Users_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Invites_Users_UsedByUserId",
+                        column: x => x.UsedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "RefreshTokens",
                 columns: table => new
                 {
@@ -223,6 +252,22 @@ namespace Anichron.Core.Migrations
                 unique: true);
 
             migrationBuilder.CreateIndex(
+                name: "IX_Invites_CreatedByUserId",
+                table: "Invites",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invites_TokenHash",
+                table: "Invites",
+                column: "TokenHash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Invites_UsedByUserId",
+                table: "Invites",
+                column: "UsedByUserId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_MediaAsset_Flashback",
                 table: "MediaAssets",
                 columns: new[] { "Month", "Day" });
@@ -313,6 +358,9 @@ namespace Anichron.Core.Migrations
                 name: "Interactions");
 
             migrationBuilder.DropTable(
+                name: "Invites");
+
+            migrationBuilder.DropTable(
                 name: "Metadata");
 
             migrationBuilder.DropTable(
@@ -326,10 +374,6 @@ namespace Anichron.Core.Migrations
 
             migrationBuilder.DropTable(
                 name: "Bursts");
-
-            migrationBuilder.DropIndex(
-                name: "IX_StorageConfigs_RootPath",
-                table: "StorageConfigs");
 
             migrationBuilder.DropTable(
                 name: "StorageConfigs");

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
@@ -36,7 +36,7 @@ namespace Anichron.Core.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    TokenHash = table.Column<string>(type: "text", nullable: false),
+                    TokenHash = table.Column<string>(type: "character varying(44)", maxLength: 44, nullable: false),
                     CreatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
                     ExpiresAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
                     UsedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
@@ -234,6 +234,14 @@ namespace Anichron.Core.Migrations
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                 });
+
+            migrationBuilder.AddColumn<uint>(
+                name: "xmin",
+                table: "Invites",
+                type: "xid",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: 0u);
 
             migrationBuilder.CreateIndex(
                 name: "IX_Bursts_PrimaryAssetId",

--- a/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
+++ b/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
@@ -96,13 +96,20 @@ namespace Anichron.Core.Migrations
 
                     b.Property<string>("TokenHash")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasMaxLength(44)
+                        .HasColumnType("character varying(44)");
 
                     b.Property<Instant?>("UsedAt")
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<Guid?>("UsedByUserId")
                         .HasColumnType("uuid");
+
+                    b.Property<uint>("xmin")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
 
                     b.HasKey("Id");
 

--- a/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
+++ b/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
@@ -79,6 +79,43 @@ namespace Anichron.Core.Migrations
                     b.ToTable("Bursts");
                 });
 
+            modelBuilder.Entity("Anichron.Core.Domain.Invite", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<Instant>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("CreatedByUserId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Instant>("ExpiresAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("TokenHash")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<Instant?>("UsedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid?>("UsedByUserId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CreatedByUserId");
+
+                    b.HasIndex("TokenHash")
+                        .IsUnique();
+
+                    b.HasIndex("UsedByUserId");
+
+                    b.ToTable("Invites");
+                });
+
             modelBuilder.Entity("Anichron.Core.Domain.MediaAsset", b =>
                 {
                     b.Property<Guid>("Id")
@@ -346,6 +383,24 @@ namespace Anichron.Core.Migrations
                         .IsRequired();
 
                     b.Navigation("PrimaryAsset");
+                });
+
+            modelBuilder.Entity("Anichron.Core.Domain.Invite", b =>
+                {
+                    b.HasOne("Anichron.Core.Domain.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedByUserId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("Anichron.Core.Domain.User", "UsedBy")
+                        .WithMany()
+                        .HasForeignKey("UsedByUserId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.Navigation("CreatedBy");
+
+                    b.Navigation("UsedBy");
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.MediaAsset", b =>


### PR DESCRIPTION
## Summary

Closes #105, #106.

- **Invite-gated registration** — `POST /auth/register` now requires a valid invite token. Tokens are SHA-256 hashed, validated for expiry and prior use, and marked used atomically on successful registration.
- **Admin password reset endpoint** — `POST /api/v1/users/{userId}/password-reset` lets an admin issue a cryptographically random temporary password. The user's session tokens are all revoked and `MustChangePassword` is set to `true`.
- **Bootstrap escape hatch** — `BootstrapResetService` handles the `ADMIN_RESET_PASSWORD` env-var startup flow, completely separated from the API-facing `AdminResetService`.
- **`InitialSchema` migration** — single EF Core migration covering the full schema including the new `invites` table (unique index on `token_hash`, FK `created_by` Restrict, FK `used_by` SetNull).

## Test plan

- [x] `AuthServiceTests` — invite token invalid / expired / already used / success (token marked used, user created)
- [x] `AdminResetServiceTests` — user not found returns null, password hashed, `MustChangePassword = true`, tokens revoked, changes saved
- [x] `BootstrapResetServiceTests` — no password configured skips, target username set/not found, no admins, multiple admins, single admin resets and saves
- [x] `AdminEndpointsTests` — reset endpoint delegates to service and mapper correctly
- [x] `AuthResponseMapperTests` — `InviteTokenInvalid → 422`, admin create user success/conflict, admin reset password 200/404

🤖 Generated with [Claude Code](https://claude.com/claude-code)