### PR TITLE
feat(health): Add health check endpoint (#82)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pages: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
 
@@ -71,6 +73,32 @@ jobs:
           git add coverage.svg
           git diff --staged --quiet || git commit -m "chore: update coverage badge"
           git push --force origin badges
+
+      - name: Prepare coverage report for Pages
+        if: github.ref == 'refs/heads/master'
+        run: cp coverage/report/index.htm coverage/report/index.html
+
+      - name: Upload coverage report to Pages
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: coverage/report/
+
+  deploy-pages:
+    name: Deploy coverage report to Pages
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.ref == 'refs/heads/master'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   docker:
     name: Docker — ${{ matrix.name }}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A self-hosted media flashback system. Crawls your a folder and surfaces your pho
 ## Status
 
 ![CI](https://github.com/bitbiter-dev/anichron/actions/workflows/ci.yml/badge.svg?branch=master)
-![Coverage](https://raw.githubusercontent.com/bitbiter-dev/anichron/badges/coverage.svg)
+[![Coverage](https://raw.githubusercontent.com/bitbiter-dev/anichron/badges/coverage.svg)](https://bitbiter-dev.github.io/anichron/)
 
 Early development — Follow progress in [Issues](https://github.com/bitbiter-dev/anichron/issues) and [Milestones](https://github.com/bitbiter-dev/anichron/milestones).
 

--- a/src/Anichron.API.Tests.Unit/Infrastructure/HealthCheckResponseWriterTests.cs
+++ b/src/Anichron.API.Tests.Unit/Infrastructure/HealthCheckResponseWriterTests.cs
@@ -1,0 +1,86 @@
+using Anichron.API.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Text.Json;
+
+namespace Anichron.API.Tests.Unit.Infrastructure;
+
+public sealed class HealthCheckResponseWriterTests
+{
+    private static DefaultHttpContext BuildContext()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        return context;
+    }
+
+    private static HealthReport BuildReport(params (string name, HealthStatus status)[] entries)
+    {
+        var dict = entries.ToDictionary(
+            e => e.name,
+            e => new HealthReportEntry(e.status, description: null, TimeSpan.Zero, exception: null, data: null));
+        return new HealthReport(dict, TimeSpan.Zero);
+    }
+
+    private static async Task<string> ReadBodyAsync(HttpResponse response)
+    {
+        response.Body.Seek(0, SeekOrigin.Begin);
+        return await new StreamReader(response.Body).ReadToEndAsync();
+    }
+
+    [Fact]
+    public async Task WriteResponseAsync_AllHealthy_WritesCorrectContentTypeAndJson()
+    {
+        var context = BuildContext();
+        var report = BuildReport(("database", HealthStatus.Healthy), ("proxyStorage", HealthStatus.Healthy));
+
+        await HealthCheckResponseWriter.WriteResponseAsync(context, report);
+        var body = await ReadBodyAsync(context.Response);
+
+        context.Response.ContentType.Should().Be("application/json; charset=utf-8");
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("healthy");
+        doc.RootElement.GetProperty("components").GetProperty("database").GetString().Should().Be("healthy");
+        doc.RootElement.GetProperty("components").GetProperty("proxyStorage").GetString().Should().Be("healthy");
+    }
+
+    [Fact]
+    public async Task WriteResponseAsync_UnhealthyComponent_WritesUnhealthyOverallStatus()
+    {
+        var context = BuildContext();
+        var report = BuildReport(("database", HealthStatus.Unhealthy), ("proxyStorage", HealthStatus.Healthy));
+
+        await HealthCheckResponseWriter.WriteResponseAsync(context, report);
+        var body = await ReadBodyAsync(context.Response);
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("unhealthy");
+        doc.RootElement.GetProperty("components").GetProperty("database").GetString().Should().Be("unhealthy");
+        doc.RootElement.GetProperty("components").GetProperty("proxyStorage").GetString().Should().Be("healthy");
+    }
+
+    [Fact]
+    public async Task WriteResponseAsync_DegradedComponent_WritesDegradedStatus()
+    {
+        var context = BuildContext();
+        var report = BuildReport(("database", HealthStatus.Degraded));
+
+        await HealthCheckResponseWriter.WriteResponseAsync(context, report);
+        var body = await ReadBodyAsync(context.Response);
+
+        using var doc = JsonDocument.Parse(body);
+        doc.RootElement.GetProperty("status").GetString().Should().Be("degraded");
+        doc.RootElement.GetProperty("components").GetProperty("database").GetString().Should().Be("degraded");
+    }
+
+    [Fact]
+    public async Task WriteResponseAsync_Always_SetsCacheControlNoStore()
+    {
+        var context = BuildContext();
+        var report = BuildReport(("database", HealthStatus.Healthy));
+
+        await HealthCheckResponseWriter.WriteResponseAsync(context, report);
+
+        context.Response.Headers.CacheControl.ToString().Should().Be("no-store");
+    }
+}

--- a/src/Anichron.API.Tests.Unit/Infrastructure/ProxyStorageHealthCheckTests.cs
+++ b/src/Anichron.API.Tests.Unit/Infrastructure/ProxyStorageHealthCheckTests.cs
@@ -1,0 +1,55 @@
+using Anichron.API.Infrastructure;
+using Anichron.API.Settings;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace Anichron.API.Tests.Unit.Infrastructure;
+
+public sealed class ProxyStorageHealthCheckTests
+{
+    private const string ProxyPath = AppDefaults.Storage.ProxyPath;
+
+    private static HealthCheckContext BuildContext() => new()
+    {
+        Registration = new HealthCheckRegistration("proxyStorage", _ => null!, default, default)
+    };
+
+    [Fact]
+    public async Task CheckHealthAsync_DirectoryExists_ReturnsHealthy()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>(),
+            new MockFileSystemOptions { CurrentDirectory = "/" });
+        fs.Directory.CreateDirectory(ProxyPath);
+        var testee = new ProxyStorageHealthCheck(fs);
+
+        var result = await testee.CheckHealthAsync(BuildContext(), CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Description.Should().Be("Proxy storage directory found.");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_DirectoryDoesNotExist_ReturnsDegraded()
+    {
+        var fs = new MockFileSystem();
+        var testee = new ProxyStorageHealthCheck(fs);
+
+        var result = await testee.CheckHealthAsync(BuildContext(), CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Description.Should().Be("Proxy storage directory not found.");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_FileSystemThrows_ReturnsUnhealthy()
+    {
+        var fs = Substitute.For<System.IO.Abstractions.IFileSystem>();
+        fs.Directory.Exists(Arg.Any<string?>()).Returns(_ => throw new IOException("disk error"));
+        var testee = new ProxyStorageHealthCheck(fs);
+
+        var result = await testee.CheckHealthAsync(BuildContext(), CancellationToken.None);
+
+        result.Status.Should().Be(HealthStatus.Unhealthy);
+        result.Exception.Should().BeOfType<IOException>();
+    }
+}

--- a/src/Anichron.API/Anichron.API.csproj
+++ b/src/Anichron.API/Anichron.API.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
   </ItemGroup>

--- a/src/Anichron.API/Infrastructure/ApiPaths.cs
+++ b/src/Anichron.API/Infrastructure/ApiPaths.cs
@@ -3,6 +3,7 @@ namespace Anichron.API.Infrastructure;
 internal static class ApiPaths
 {
     internal const string Base = "/api/v1";
+    internal const string Healthz = $"{Base}/healthz";
 
     internal static class Auth
     {

--- a/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ApplicationExtensions.cs
@@ -3,6 +3,7 @@ using Anichron.API.Services;
 using Anichron.API.Settings;
 using Anichron.Core.Data;
 using Anichron.Infrastructure.Data;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 
 namespace Anichron.API.Infrastructure;
 
@@ -12,6 +13,11 @@ public static partial class ApplicationExtensions
     {
         public WebApplication MapApiEndpoints()
         {
+            app.MapHealthChecks(ApiPaths.Healthz, new HealthCheckOptions
+            {
+                ResponseWriter = HealthCheckResponseWriter.WriteResponseAsync
+            }).AllowAnonymous();
+
             var api = app.MapGroup(ApiPaths.Base);
             api.MapAuthEndpoints();
             api.MapUserEndpoints();

--- a/src/Anichron.API/Infrastructure/HealthCheckResponseWriter.cs
+++ b/src/Anichron.API/Infrastructure/HealthCheckResponseWriter.cs
@@ -6,7 +6,6 @@ internal static class HealthCheckResponseWriter
 {
     internal static async Task WriteResponseAsync(HttpContext context, HealthReport report)
     {
-        context.Response.ContentType = "application/json; charset=utf-8";
         context.Response.Headers.CacheControl = "no-store";
         var response = new
         {

--- a/src/Anichron.API/Infrastructure/HealthCheckResponseWriter.cs
+++ b/src/Anichron.API/Infrastructure/HealthCheckResponseWriter.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Anichron.API.Infrastructure;
+
+internal static class HealthCheckResponseWriter
+{
+    internal static async Task WriteResponseAsync(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json; charset=utf-8";
+        context.Response.Headers.CacheControl = "no-store";
+        var response = new
+        {
+            status = report.Status.ToString().ToLowerInvariant(),
+            components = report.Entries.ToDictionary(
+                e => e.Key,
+                e => e.Value.Status.ToString().ToLowerInvariant())
+        };
+        await context.Response.WriteAsJsonAsync(response);
+    }
+}

--- a/src/Anichron.API/Infrastructure/ProxyStorageHealthCheck.cs
+++ b/src/Anichron.API/Infrastructure/ProxyStorageHealthCheck.cs
@@ -1,0 +1,23 @@
+using Anichron.API.Settings;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.IO.Abstractions;
+
+namespace Anichron.API.Infrastructure;
+
+internal sealed class ProxyStorageHealthCheck(IFileSystem fileSystem) : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return Task.FromResult(
+                fileSystem.Directory.Exists(AppDefaults.Storage.ProxyPath)
+                    ? HealthCheckResult.Healthy("Proxy storage directory found.")
+                    : HealthCheckResult.Degraded("Proxy storage directory not found."));
+        }
+        catch (Exception ex)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy("Proxy storage check failed.", ex));
+        }
+    }
+}

--- a/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
@@ -180,5 +180,14 @@ public static class ServiceCollectionExtensions
                 options.AddPolicy(AuthPolicies.Admin,
                     policy => policy.RequireClaim(AppClaimTypes.IsAdmin, "true")));
         }
+
+        public IServiceCollection AddApiHealthChecks()
+        {
+            services.AddSingleton<IFileSystem, FileSystem>();
+            services.AddHealthChecks()
+                    .AddDbContextCheck<AnichronDbContext>("database")
+                    .AddCheck<ProxyStorageHealthCheck>("proxyStorage");
+            return services;
+        }
     }
 }

--- a/src/Anichron.API/Program.cs
+++ b/src/Anichron.API/Program.cs
@@ -11,7 +11,8 @@ builder.Services
     .AddAuthorization()
     .AddAuthorizationPolicies()
     .AddRateLimiting()
-    .AddCorsPolicy(builder.Configuration);
+    .AddCorsPolicy(builder.Configuration)
+    .AddApiHealthChecks();
 
 var app = builder.Build();
 

--- a/src/Anichron.API/Settings/AppDefaults.cs
+++ b/src/Anichron.API/Settings/AppDefaults.cs
@@ -69,6 +69,11 @@ internal static class AppDefaults
         internal const int BackoffBase = 2;
     }
 
+    internal static class Storage
+    {
+        internal const string ProxyPath = "/data/proxies";
+    }
+
     internal static class Startup
     {
         internal const int MaxDbRetryAttempts = 10;

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 10s
+      start_period: 30s
     depends_on:
       anichron-db:
         condition: service_healthy

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -47,6 +47,12 @@ services:
     volumes:
       - /path/to/your/nas:/data/originals:ro
       - ${BASE_PATH}/anichron/proxy_cache:/data/proxies:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/v1/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     depends_on:
       anichron-db:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/healthz` returning JSON with overall and per-component status (`healthy` / `degraded` / `unhealthy`)
- Checks EF Core database connectivity and proxy storage directory (`/data/proxies`) on every request
- Proxy storage missing → `Degraded` (API still functional); file system error → `Unhealthy`
- Response always carries `Cache-Control: no-store` to prevent monitoring tools from caching stale health state
- Wires a `healthcheck` in `docker-compose.yml` so the container reports healthy/unhealthy to the Docker daemon

## Test plan

- [ ] `dotnet test` — all 278 tests pass
- [ ] `ProxyStorageHealthCheckTests` covers: directory exists (Healthy + description), missing (Degraded + description), FS exception (Unhealthy + exception)
- [ ] `HealthCheckResponseWriterTests` covers: content-type, healthy/unhealthy/degraded JSON serialisation, `Cache-Control: no-store` header
- [ ] Manual: `curl -s http://localhost:5207/api/v1/healthz` returns `{"status":"healthy","components":{...}}`; no `Authorization` header required

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)