### PR TITLE
refactor(worker): Organise services into Crawling/ and Maintenance/ subfolders

### DIFF
--- a/src/Anichron.Worker.Tests.Unit/Maintenance/TokenCleanupServiceTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Maintenance/TokenCleanupServiceTests.cs
@@ -1,11 +1,12 @@
 using Anichron.Core.Data.Repository;
+using Anichron.Worker.Maintenance;
 using Anichron.Worker.Settings;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NodaTime;
 
-namespace Anichron.Worker.Tests.Unit;
+namespace Anichron.Worker.Tests.Unit.Maintenance;
 
 public sealed class TokenCleanupServiceTests
 {

--- a/src/Anichron.Worker.Tests.Unit/Startup/WorkerInitializerTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Startup/WorkerInitializerTests.cs
@@ -1,6 +1,7 @@
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Core.Domain;
+using Anichron.Worker.Crawling;
 using Anichron.Worker.Settings;
 using Anichron.Worker.Startup;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Anichron.Worker/Crawling/Worker.cs
+++ b/src/Anichron.Worker/Crawling/Worker.cs
@@ -3,7 +3,7 @@ using Anichron.Core.Domain;
 using Anichron.Worker.Settings;
 using Microsoft.Extensions.Options;
 
-namespace Anichron.Worker;
+namespace Anichron.Worker.Crawling;
 
 public sealed partial class Worker(
     IServiceScopeFactory scopeFactory,

--- a/src/Anichron.Worker/Crawling/WorkerState.cs
+++ b/src/Anichron.Worker/Crawling/WorkerState.cs
@@ -1,4 +1,4 @@
-namespace Anichron.Worker;
+namespace Anichron.Worker.Crawling;
 
 public sealed class WorkerState
 {

--- a/src/Anichron.Worker/Maintenance/TokenCleanupService.cs
+++ b/src/Anichron.Worker/Maintenance/TokenCleanupService.cs
@@ -3,7 +3,7 @@ using Anichron.Worker.Settings;
 using Microsoft.Extensions.Options;
 using NodaTime;
 
-namespace Anichron.Worker;
+namespace Anichron.Worker.Maintenance;
 
 public sealed partial class TokenCleanupService(
     IServiceScopeFactory scopeFactory,

--- a/src/Anichron.Worker/Program.cs
+++ b/src/Anichron.Worker/Program.cs
@@ -1,8 +1,9 @@
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Infrastructure.Configuration;
-using Anichron.Worker;
+using Anichron.Worker.Crawling;
 using Anichron.Worker.Infrastructure;
+using Anichron.Worker.Maintenance;
 using Anichron.Worker.Settings;
 using Anichron.Worker.Startup;
 using Microsoft.EntityFrameworkCore;

--- a/src/Anichron.Worker/Startup/WorkerInitializer.cs
+++ b/src/Anichron.Worker/Startup/WorkerInitializer.cs
@@ -1,6 +1,7 @@
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Core.Domain;
+using Anichron.Worker.Crawling;
 using Anichron.Worker.Settings;
 using Microsoft.Extensions.Options;
 


### PR DESCRIPTION
## Summary

- Moves `Worker` and `WorkerState` into `Anichron.Worker/Crawling/` (namespace `Anichron.Worker.Crawling`)
- Moves `TokenCleanupService` into `Anichron.Worker/Maintenance/` (namespace `Anichron.Worker.Maintenance`)
- Moves `TokenCleanupServiceTests` into `Anichron.Worker.Tests.Unit/Maintenance/` accordingly
- Updates `Program.cs`, `WorkerInitializer.cs`, and `WorkerInitializerTests.cs` with the new using directives

## Test plan

- [ ] `dotnet build src/` passes (0 errors, 0 warnings)
- [ ] `dotnet test src/` passes (294 tests, 0 failures)
- [ ] `dotnet format src/ --verify-no-changes` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)