### PR TITLE
feat(auth): Enforce MustChangePassword — block all endpoints except profile and logout

### DIFF
--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthEndpointsTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthEndpointsTests.cs
@@ -1,5 +1,4 @@
 using Anichron.API.Endpoints;
-using Anichron.API.Infrastructure;
 using Anichron.API.Services;
 using Anichron.API.Settings;
 using Microsoft.AspNetCore.Http;
@@ -151,7 +150,7 @@ public sealed class AuthEndpointsTests
     {
         var auth = Substitute.For<IAuthService>();
         var mapper = Substitute.For<IAuthResponseMapper>();
-        var http = NewHttpWithCookie(AuthMessages.RefreshTokenCookieName, "cookie_tok");
+        var http = NewHttpWithCookie("refresh_token", "cookie_tok");
         auth.RefreshAsync("cookie_tok", Arg.Any<CancellationToken>())
             .Returns(AuthResult.Ok(new AuthTokens("access", "refresh")));
 
@@ -197,7 +196,7 @@ public sealed class AuthEndpointsTests
     {
         var auth = Substitute.For<IAuthService>();
         var mapper = Substitute.For<IAuthResponseMapper>();
-        var http = NewHttpWithCookie(AuthMessages.RefreshTokenCookieName, "cookie_tok");
+        var http = NewHttpWithCookie("refresh_token", "cookie_tok");
 
         var result = await AuthEndpoints.LogoutAsync(http, auth, mapper, req: null, CancellationToken.None);
 

--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
@@ -1,5 +1,4 @@
 using Anichron.API.Endpoints;
-using Anichron.API.Infrastructure;
 using Anichron.API.Services;
 using Anichron.API.Settings;
 using Microsoft.AspNetCore.Http;
@@ -340,7 +339,7 @@ public sealed class AuthResponseMapperTests
 
         testee.ClearRefreshCookie(http);
 
-        http.Response.Headers.SetCookie.ToString().Should().Contain(AuthMessages.RefreshTokenCookieName);
+        http.Response.Headers.SetCookie.ToString().Should().Contain("refresh_token");
     }
 
     // ==========================================================================
@@ -372,7 +371,7 @@ public sealed class AuthResponseMapperTests
         Assert.Multiple(() =>
         {
             http.Response.StatusCode.Should().Be(400);
-            body.Should().Contain(AuthMessages.InvalidCredentials);
+            body.Should().Contain("The username, email, or password is incorrect.");
         });
     }
 
@@ -425,7 +424,7 @@ public sealed class AuthResponseMapperTests
         Assert.Multiple(() =>
         {
             http.Response.StatusCode.Should().Be(422);
-            body.Should().Contain(AuthMessages.PasswordPwned);
+            body.Should().Contain("This password has appeared in a known data breach. Please choose a different one.");
         });
     }
 

--- a/src/Anichron.API.Tests.Unit/Endpoints/UserEndpointsTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/UserEndpointsTests.cs
@@ -1,5 +1,4 @@
 using Anichron.API.Endpoints;
-using Anichron.API.Infrastructure;
 using Anichron.API.Services;
 using Anichron.API.Settings;
 using Anichron.Core.Data.Repository;
@@ -188,7 +187,7 @@ public sealed class UserEndpointsTests
         var policy = new PasswordPolicy();
         var options = Options.Create(policy);
         var failureResult = AuthResult.Fail(AuthError.InvalidCredentials);
-        var expectedResult = Results.Json(new { error = AuthMessages.InvalidCredentials }, statusCode: 400);
+        var expectedResult = Results.Json(new { error = "The username, email, or password is incorrect." }, statusCode: 400);
         authService.ChangePasswordAsync(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(failureResult);
         mapper.GetChangePasswordResult(failureResult, policy)

--- a/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
+++ b/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
@@ -24,7 +24,7 @@ public sealed class MustChangePasswordMiddlewareTests
     private static ClaimsPrincipal Unauthenticated()
         => new(new ClaimsIdentity());
 
-    private static Claim MustChangeClaim() => new(AppClaimTypes.MustChangePassword, "true");
+    private static Claim MustChangeClaim() => new("must_change_password", "true");
 
     private static async Task<string> ReadBodyAsync(HttpResponse response)
     {
@@ -66,7 +66,7 @@ public sealed class MustChangePasswordMiddlewareTests
     public async Task InvokeAsync_AuthenticatedWithClaimValueFalse_CallsNext()
     {
         var context = BuildContext(
-            Authenticated(new Claim(AppClaimTypes.MustChangePassword, "false")),
+            Authenticated(new Claim("must_change_password", "false")),
             HttpMethods.Get, "/api/v1/some/endpoint");
         var nextCalled = false;
         var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });

--- a/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
+++ b/src/Anichron.API.Tests.Unit/Infrastructure/MustChangePasswordMiddlewareTests.cs
@@ -103,6 +103,19 @@ public sealed class MustChangePasswordMiddlewareTests
         context.Response.StatusCode.Should().Be(200);
     }
 
+    [Fact]
+    public async Task InvokeAsync_AuthenticatedWithClaim_GetMePath_CallsNext()
+    {
+        var context = BuildContext(Authenticated(MustChangeClaim()), HttpMethods.Get, "/api/v1/users/me");
+        var nextCalled = false;
+        var middleware = new MustChangePasswordMiddleware(_ => { nextCalled = true; return Task.CompletedTask; });
+
+        await middleware.InvokeAsync(context);
+
+        nextCalled.Should().BeTrue();
+        context.Response.StatusCode.Should().Be(200);
+    }
+
     // ==========================================================================
     // Returns 403
     // ==========================================================================

--- a/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
+++ b/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
@@ -8,11 +8,14 @@ internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
     private static readonly PathString LogoutPath =
         new($"{ApiPaths.Base}/{ApiPaths.Auth.Group}{ApiPaths.Auth.Logout}");
 
+    private static readonly PathString GetMePath =
+        new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Users.Me}");
+
     public async Task InvokeAsync(HttpContext context)
     {
         if (context.User.Identity?.IsAuthenticated == true
             && context.User.HasClaim(AppClaimTypes.MustChangePassword, "true")
-            && !IsExemptPostRequest(context.Request))
+            && !IsExemptRequest(context.Request))
         {
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsJsonAsync(new { error = AuthMessages.MustChangePassword });
@@ -22,8 +25,10 @@ internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
         await next(context);
     }
 
-    private static bool IsExemptPostRequest(HttpRequest request)
+    private static bool IsExemptRequest(HttpRequest request)
     {
+        if (request.Method == HttpMethods.Get && request.Path == GetMePath)
+            return true;
         return request.Method == HttpMethods.Post
             && (request.Path == ChangePasswordPath || request.Path == LogoutPath);
     }

--- a/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
+++ b/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
@@ -2,14 +2,12 @@ namespace Anichron.API.Infrastructure;
 
 internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
 {
-    private static readonly PathString ChangePasswordPath =
-        new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Users.ChangePassword}");
-
-    private static readonly PathString LogoutPath =
-        new($"{ApiPaths.Base}/{ApiPaths.Auth.Group}{ApiPaths.Auth.Logout}");
-
-    private static readonly PathString GetMePath =
-        new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Users.Me}");
+    private static readonly (string Method, PathString Path)[] ExemptRoutes =
+    [
+        (HttpMethods.Get,  new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Users.Me}")),
+        (HttpMethods.Post, new($"{ApiPaths.Base}/{ApiPaths.Users.Group}{ApiPaths.Users.ChangePassword}")),
+        (HttpMethods.Post, new($"{ApiPaths.Base}/{ApiPaths.Auth.Group}{ApiPaths.Auth.Logout}")),
+    ];
 
     public async Task InvokeAsync(HttpContext context)
     {
@@ -26,10 +24,5 @@ internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
     }
 
     private static bool IsExemptRequest(HttpRequest request)
-    {
-        if (request.Method == HttpMethods.Get && request.Path == GetMePath)
-            return true;
-        return request.Method == HttpMethods.Post
-            && (request.Path == ChangePasswordPath || request.Path == LogoutPath);
-    }
+        => ExemptRoutes.Any(e => e.Method == request.Method && e.Path == request.Path);
 }


### PR DESCRIPTION
## Summary

`MustChangePasswordMiddleware` was already implemented and wired into the pipeline. This PR completes the feature by adding the missing `GET /users/me` exemption and its test.

**Before:** users with `must_change_password=true` could not access their own profile, preventing the client from showing the appropriate UI.

**After:** the three exemptions are:
- `GET /api/v1/users/me` — read own profile (new)
- `POST /api/v1/users/me/password` — change password
- `POST /api/v1/auth/logout` — log out

All other JWT-protected endpoints return `403` with `{ "error": "Password change required before continuing." }`.

## Test plan

- [x] `dotnet build src/` passes (0 errors, 0 warnings)
- [x] `dotnet test src/` passes (295 tests, 0 failures)
- [x] `dotnet format src/ --verify-no-changes` passes

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)