### PR TITLE
feat(admin): Add user listing and management endpoints (#84)

### DIFF
--- a/src/Anichron.API.Tests.Unit/Endpoints/AdminUserEndpointsTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AdminUserEndpointsTests.cs
@@ -1,0 +1,129 @@
+using Anichron.API.Endpoints;
+using Anichron.API.Services;
+using Anichron.Core.Domain;
+using Microsoft.AspNetCore.Http;
+using System.Security.Claims;
+
+namespace Anichron.API.Tests.Unit.Endpoints;
+
+public sealed class AdminUserEndpointsTests
+{
+    private static ClaimsPrincipal PrincipalWithGuid(Guid id)
+        => new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, id.ToString())]));
+
+    private static ClaimsPrincipal PrincipalWithoutNameIdentifier()
+        => new(new ClaimsIdentity([]));
+
+    // ==========================================================================
+    // GetUsersAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetUsersAsync_CallsServiceAndReturnsMapperResult()
+    {
+        var service = Substitute.For<IAdminUserService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var users = new List<User>();
+        var expected = Results.Ok(users);
+        service.GetAllAsync(Arg.Any<CancellationToken>()).Returns(users);
+        mapper.GetAdminGetUsersResult(users).Returns(expected);
+
+        var result = await AdminEndpoints.GetUsersAsync(service, mapper, CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+    }
+
+    // ==========================================================================
+    // GetUserAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetUserAsync_PassesUserIdToServiceAndReturnsMapperResult()
+    {
+        var service = Substitute.For<IAdminUserService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId };
+        var expected = Results.Ok(user);
+        service.GetByIdAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+        mapper.GetAdminGetUserResult(user).Returns(expected);
+
+        var result = await AdminEndpoints.GetUserAsync(userId, service, mapper, CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+    }
+
+    // ==========================================================================
+    // PatchUserAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task PatchUserAsync_NoNameIdentifierClaim_ReturnsUnauthorized()
+    {
+        var service = Substitute.For<IAdminUserService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+
+        var result = await AdminEndpoints.PatchUserAsync(
+            Guid.NewGuid(), new PatchAdminUserRequest(null, null),
+            PrincipalWithoutNameIdentifier(), service, mapper, CancellationToken.None);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(401);
+        await service.DidNotReceive().UpdateAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<bool?>(), Arg.Any<bool?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task PatchUserAsync_PassesCallerAndTargetIdsAndReturnsMappedResult()
+    {
+        var service = Substitute.For<IAdminUserService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var callerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+        var req = new PatchAdminUserRequest(IsAdmin: true, IsDisabled: null);
+        var serviceResult = AuthResult.Ok(new User { Id = targetId, StorageConfigs = [] });
+        var expected = Results.Ok();
+        service.UpdateAsync(callerId, targetId, true, null, Arg.Any<CancellationToken>()).Returns(serviceResult);
+        mapper.GetAdminPatchUserResult(serviceResult).Returns(expected);
+
+        var result = await AdminEndpoints.PatchUserAsync(
+            targetId, req, PrincipalWithGuid(callerId), service, mapper, CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+        await service.Received(1).UpdateAsync(callerId, targetId, true, null, Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // DeleteUserAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task DeleteUserAsync_NoNameIdentifierClaim_ReturnsUnauthorized()
+    {
+        var service = Substitute.For<IAdminUserService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+
+        var result = await AdminEndpoints.DeleteUserAsync(
+            Guid.NewGuid(), PrincipalWithoutNameIdentifier(), service, mapper, CancellationToken.None);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(401);
+        await service.DidNotReceive().DeleteAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteUserAsync_PassesCallerAndTargetIdsAndReturnsMappedResult()
+    {
+        var service = Substitute.For<IAdminUserService>();
+        var mapper = Substitute.For<IAuthResponseMapper>();
+        var callerId = Guid.NewGuid();
+        var targetId = Guid.NewGuid();
+        var serviceResult = AuthResult.Ok();
+        var expected = Results.NoContent();
+        service.DeleteAsync(callerId, targetId, Arg.Any<CancellationToken>()).Returns(serviceResult);
+        mapper.GetAdminDeleteUserResult(serviceResult).Returns(expected);
+
+        var result = await AdminEndpoints.DeleteUserAsync(
+            targetId, PrincipalWithGuid(callerId), service, mapper, CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+        await service.Received(1).DeleteAsync(callerId, targetId, Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
@@ -644,13 +644,13 @@ public sealed class AuthResponseMapperTests
     }
 
     [Fact]
-    public void GetAdminPatchUserResult_CannotModifySelf_Returns400()
+    public void GetAdminPatchUserResult_CannotModifySelf_Returns403()
     {
         var testee = new TestFixture().CreateTestee();
 
         var result = testee.GetAdminPatchUserResult(AuthResult.Fail<Core.Domain.User>(AuthError.CannotModifySelf));
 
-        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(400);
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(403);
     }
 
     [Fact]
@@ -698,13 +698,13 @@ public sealed class AuthResponseMapperTests
     }
 
     [Fact]
-    public void GetAdminDeleteUserResult_CannotModifySelf_Returns400()
+    public void GetAdminDeleteUserResult_CannotModifySelf_Returns403()
     {
         var testee = new TestFixture().CreateTestee();
 
         var result = testee.GetAdminDeleteUserResult(AuthResult.Fail(AuthError.CannotModifySelf));
 
-        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(400);
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(403);
     }
 
     [Fact]

--- a/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
+++ b/src/Anichron.API.Tests.Unit/Endpoints/AuthResponseMapperTests.cs
@@ -528,4 +528,202 @@ public sealed class AuthResponseMapperTests
         ok.StatusCode.Should().Be(200);
         ok.Value.Should().Be(new AdminPasswordResetResponse("TempPass=="));
     }
+
+    // ==========================================================================
+    // GetAdminGetUsersResult
+    // ==========================================================================
+
+    [Fact]
+    public void GetAdminGetUsersResult_EmptyList_Returns200WithEmptyCollection()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminGetUsersResult([]);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(200);
+    }
+
+    [Fact]
+    public void GetAdminGetUsersResult_WithUsers_Returns200WithMappedResponses()
+    {
+        var testee = new TestFixture().CreateTestee();
+        var userId = new Guid("11111111-0000-0000-0000-000000000001");
+        var user = new Core.Domain.User
+        {
+            Id = userId,
+            Username = "alice",
+            Email = "alice@example.com",
+            IsAdmin = true,
+            IsDisabled = false,
+            StorageConfigs = [new() { Id = Guid.NewGuid() }, new() { Id = Guid.NewGuid() }],
+        };
+
+        var ok = testee.GetAdminGetUsersResult([user])
+            .Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<List<AdminUserResponse>>>().Subject;
+
+        ok.StatusCode.Should().Be(200);
+        ok.Value.Should().ContainSingle(r =>
+            r.Id == userId &&
+            r.Username == "alice" &&
+            r.Email == "alice@example.com" &&
+            r.IsAdmin &&
+            !r.IsDisabled &&
+            r.StorageConfigCount == 2);
+    }
+
+    // ==========================================================================
+    // GetAdminGetUserResult
+    // ==========================================================================
+
+    [Fact]
+    public void GetAdminGetUserResult_NullUser_Returns404()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminGetUserResult(null);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public void GetAdminGetUserResult_UserFound_Returns200WithMappedResponse()
+    {
+        var testee = new TestFixture().CreateTestee();
+        var userId = new Guid("22222222-0000-0000-0000-000000000002");
+        var user = new Core.Domain.User
+        {
+            Id = userId,
+            Username = "bob",
+            Email = "bob@example.com",
+            IsAdmin = false,
+            IsDisabled = true,
+            StorageConfigs = [new() { Id = Guid.NewGuid() }],
+        };
+
+        var ok = testee.GetAdminGetUserResult(user)
+            .Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<AdminUserResponse>>().Subject;
+
+        ok.StatusCode.Should().Be(200);
+        ok.Value.Should().Be(new AdminUserResponse(userId, "bob", "bob@example.com", false, true, 1));
+    }
+
+    // ==========================================================================
+    // GetAdminPatchUserResult
+    // ==========================================================================
+
+    [Fact]
+    public void GetAdminPatchUserResult_Success_Returns200WithMappedUser()
+    {
+        var testee = new TestFixture().CreateTestee();
+        var userId = new Guid("33333333-0000-0000-0000-000000000003");
+        var user = new Core.Domain.User
+        {
+            Id = userId,
+            Username = "carol",
+            Email = "carol@example.com",
+            IsAdmin = true,
+            IsDisabled = false,
+            StorageConfigs = [],
+        };
+
+        var ok = testee.GetAdminPatchUserResult(AuthResult.Ok(user))
+            .Should().BeOfType<Microsoft.AspNetCore.Http.HttpResults.Ok<AdminUserResponse>>().Subject;
+
+        ok.StatusCode.Should().Be(200);
+        ok.Value.Should().Be(new AdminUserResponse(userId, "carol", "carol@example.com", true, false, 0));
+    }
+
+    [Fact]
+    public void GetAdminPatchUserResult_UserNotFound_Returns404()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminPatchUserResult(AuthResult.Fail<Core.Domain.User>(AuthError.UserNotFound));
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public void GetAdminPatchUserResult_CannotModifySelf_Returns400()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminPatchUserResult(AuthResult.Fail<Core.Domain.User>(AuthError.CannotModifySelf));
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public void GetAdminPatchUserResult_ErrorFromOtherContext_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetAdminPatchUserResult(AuthResult.Fail<Core.Domain.User>(AuthError.InvalidCredentials));
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
+
+    [Fact]
+    public void GetAdminPatchUserResult_UndefinedAuthError_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetAdminPatchUserResult(AuthResult.Fail<Core.Domain.User>((AuthError)999));
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
+
+    // ==========================================================================
+    // GetAdminDeleteUserResult
+    // ==========================================================================
+
+    [Fact]
+    public void GetAdminDeleteUserResult_Success_Returns204()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminDeleteUserResult(AuthResult.Ok());
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(204);
+    }
+
+    [Fact]
+    public void GetAdminDeleteUserResult_UserNotFound_Returns404()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminDeleteUserResult(AuthResult.Fail(AuthError.UserNotFound));
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(404);
+    }
+
+    [Fact]
+    public void GetAdminDeleteUserResult_CannotModifySelf_Returns400()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var result = testee.GetAdminDeleteUserResult(AuthResult.Fail(AuthError.CannotModifySelf));
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(400);
+    }
+
+    [Fact]
+    public void GetAdminDeleteUserResult_ErrorFromOtherContext_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetAdminDeleteUserResult(AuthResult.Fail(AuthError.InvalidCredentials));
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
+
+    [Fact]
+    public void GetAdminDeleteUserResult_UndefinedAuthError_ThrowsUnreachableException()
+    {
+        var testee = new TestFixture().CreateTestee();
+
+        var act = () => testee.GetAdminDeleteUserResult(AuthResult.Fail((AuthError)999));
+
+        act.Should().Throw<System.Diagnostics.UnreachableException>();
+    }
 }

--- a/src/Anichron.API.Tests.Unit/Services/AdminUserServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AdminUserServiceTests.cs
@@ -1,0 +1,214 @@
+using Anichron.API.Services;
+using Anichron.Core.Data;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+
+namespace Anichron.API.Tests.Unit.Services;
+
+public sealed class AdminUserServiceTests
+{
+    private static readonly Instant FixedNow = Instant.FromUtc(2026, 5, 12, 10, 0, 0);
+
+    private sealed class TestFixture
+    {
+        public IUserRepository Users { get; } = Substitute.For<IUserRepository>();
+        public IUnitOfWork UnitOfWork { get; } = Substitute.For<IUnitOfWork>();
+        public ITokenService TokenService { get; } = Substitute.For<ITokenService>();
+        private readonly IClock _clock = Substitute.For<IClock>();
+
+        public TestFixture() => _clock.GetCurrentInstant().Returns(FixedNow);
+
+        public AdminUserService CreateTestee() => new(Users, UnitOfWork, _clock, TokenService);
+    }
+
+    // ==========================================================================
+    // GetAllAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllUsersFromRepository()
+    {
+        var fixture = new TestFixture();
+        var expected = new List<User> { new() { Id = Guid.NewGuid() }, new() { Id = Guid.NewGuid() } };
+        fixture.Users.GetAllAsync(Arg.Any<CancellationToken>()).Returns(expected);
+
+        var result = await fixture.CreateTestee().GetAllAsync(CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+    }
+
+    // ==========================================================================
+    // GetByIdAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetByIdAsync_UserFound_ReturnsUser()
+    {
+        var fixture = new TestFixture();
+        var userId = Guid.NewGuid();
+        var user = new User { Id = userId };
+        fixture.Users.FindByIdWithConfigsAsync(userId, Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await fixture.CreateTestee().GetByIdAsync(userId, CancellationToken.None);
+
+        result.Should().BeSameAs(user);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_UserNotFound_ReturnsNull()
+    {
+        var fixture = new TestFixture();
+        var userId = Guid.NewGuid();
+        fixture.Users.FindByIdWithConfigsAsync(userId, Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await fixture.CreateTestee().GetByIdAsync(userId, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // UpdateAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task UpdateAsync_BothParamsNull_ReturnsUserWithoutSaving()
+    {
+        var fixture = new TestFixture();
+        var user = new User { Id = Guid.NewGuid(), StorageConfigs = [] };
+        fixture.Users.FindByIdWithConfigsAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await fixture.CreateTestee().UpdateAsync(Guid.NewGuid(), user.Id, isAdmin: null, isDisabled: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeSameAs(user);
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SelfModification_ReturnsCannotModifySelf()
+    {
+        var id = Guid.NewGuid();
+        var fixture = new TestFixture();
+
+        var result = await fixture.CreateTestee().UpdateAsync(id, id, isAdmin: false, isDisabled: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(AuthError.CannotModifySelf);
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_UserNotFound_ReturnsUserNotFound()
+    {
+        var fixture = new TestFixture();
+        var targetId = Guid.NewGuid();
+        fixture.Users.FindByIdWithConfigsAsync(targetId, Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await fixture.CreateTestee().UpdateAsync(Guid.NewGuid(), targetId, isAdmin: true, isDisabled: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(AuthError.UserNotFound);
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetIsAdmin_UpdatesUserAndReturnsUpdatedUser()
+    {
+        var fixture = new TestFixture();
+        var user = new User { Id = Guid.NewGuid(), IsAdmin = false, StorageConfigs = [] };
+        fixture.Users.FindByIdWithConfigsAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await fixture.CreateTestee().UpdateAsync(Guid.NewGuid(), user.Id, isAdmin: true, isDisabled: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.IsAdmin.Should().BeTrue();
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetIsDisabledTrue_RevokesSessionsAndSaves()
+    {
+        var fixture = new TestFixture();
+        var user = new User { Id = Guid.NewGuid(), IsDisabled = false, StorageConfigs = [] };
+        fixture.Users.FindByIdWithConfigsAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        await fixture.CreateTestee().UpdateAsync(Guid.NewGuid(), user.Id, isAdmin: null, isDisabled: true, CancellationToken.None);
+
+        await fixture.TokenService.Received(1).MarkAllSessionsRevokedAsync(user.Id, FixedNow, Arg.Any<CancellationToken>());
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetIsDisabledTrue_WhenAlreadyDisabled_DoesNotRevokeSessionsButSaves()
+    {
+        var fixture = new TestFixture();
+        var user = new User { Id = Guid.NewGuid(), IsDisabled = true, StorageConfigs = [] };
+        fixture.Users.FindByIdWithConfigsAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        await fixture.CreateTestee().UpdateAsync(Guid.NewGuid(), user.Id, isAdmin: null, isDisabled: true, CancellationToken.None);
+
+        await fixture.TokenService.DidNotReceive().MarkAllSessionsRevokedAsync(Arg.Any<Guid>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetIsDisabledFalse_DoesNotRevokeSessionsButSaves()
+    {
+        var fixture = new TestFixture();
+        var user = new User { Id = Guid.NewGuid(), IsDisabled = true, StorageConfigs = [] };
+        fixture.Users.FindByIdWithConfigsAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        await fixture.CreateTestee().UpdateAsync(Guid.NewGuid(), user.Id, isAdmin: null, isDisabled: false, CancellationToken.None);
+
+        await fixture.TokenService.DidNotReceive().MarkAllSessionsRevokedAsync(Arg.Any<Guid>(), Arg.Any<Instant>(), Arg.Any<CancellationToken>());
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // DeleteAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task DeleteAsync_SelfDeletion_ReturnsCannotModifySelf()
+    {
+        var id = Guid.NewGuid();
+        var fixture = new TestFixture();
+
+        var result = await fixture.CreateTestee().DeleteAsync(id, id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(AuthError.CannotModifySelf);
+        fixture.Users.DidNotReceive().Remove(Arg.Any<User>());
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_UserNotFound_ReturnsUserNotFound()
+    {
+        var fixture = new TestFixture();
+        var targetId = Guid.NewGuid();
+        fixture.Users.FindByIdAsync(targetId, Arg.Any<CancellationToken>()).Returns((User?)null);
+
+        var result = await fixture.CreateTestee().DeleteAsync(Guid.NewGuid(), targetId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Error.Should().Be(AuthError.UserNotFound);
+        fixture.Users.DidNotReceive().Remove(Arg.Any<User>());
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_ValidUser_RevokesSessionsRemovesUserAndSaves()
+    {
+        var fixture = new TestFixture();
+        var user = new User { Id = Guid.NewGuid() };
+        fixture.Users.FindByIdAsync(user.Id, Arg.Any<CancellationToken>()).Returns(user);
+
+        var result = await fixture.CreateTestee().DeleteAsync(Guid.NewGuid(), user.Id, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        await fixture.TokenService.Received(1).MarkAllSessionsRevokedAsync(user.Id, FixedNow, Arg.Any<CancellationToken>());
+        fixture.Users.Received(1).Remove(user);
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Anichron.API/Endpoints/AdminEndpoints.cs
+++ b/src/Anichron.API/Endpoints/AdminEndpoints.cs
@@ -1,5 +1,6 @@
 using Anichron.API.Infrastructure;
 using Anichron.API.Services;
+using System.Security.Claims;
 
 namespace Anichron.API.Endpoints;
 
@@ -12,6 +13,12 @@ public static class AdminEndpoints
         group.MapPost(string.Empty, CreateUserAsync)
              .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
         group.MapPost("{userId:guid}/password-reset", ResetUserPasswordAsync)
+             .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapGet(string.Empty, GetUsersAsync);
+        group.MapGet("{userId:guid}", GetUserAsync);
+        group.MapPatch("{userId:guid}", PatchUserAsync)
+             .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
+        group.MapDelete("{userId:guid}", DeleteUserAsync)
              .RequireRateLimiting(AuthRateLimitPolicies.Sensitive);
         return app;
     }
@@ -35,8 +42,58 @@ public static class AdminEndpoints
         var result = await adminReset.ResetUserPasswordAsync(userId, ct);
         return mapper.GetAdminResetPasswordResult(result);
     }
+
+    internal static async Task<IResult> GetUsersAsync(
+        IAdminUserService adminUsers,
+        IAuthResponseMapper mapper,
+        CancellationToken ct)
+    {
+        var users = await adminUsers.GetAllAsync(ct);
+        return mapper.GetAdminGetUsersResult(users);
+    }
+
+    internal static async Task<IResult> GetUserAsync(
+        Guid userId,
+        IAdminUserService adminUsers,
+        IAuthResponseMapper mapper,
+        CancellationToken ct)
+    {
+        var user = await adminUsers.GetByIdAsync(userId, ct);
+        return mapper.GetAdminGetUserResult(user);
+    }
+
+    internal static async Task<IResult> PatchUserAsync(
+        Guid userId,
+        PatchAdminUserRequest req,
+        ClaimsPrincipal caller,
+        IAdminUserService adminUsers,
+        IAuthResponseMapper mapper,
+        CancellationToken ct)
+    {
+        if (!Guid.TryParse(caller.FindFirstValue(ClaimTypes.NameIdentifier), out var callerId))
+            return Results.Unauthorized();
+
+        var result = await adminUsers.UpdateAsync(callerId, userId, req.IsAdmin, req.IsDisabled, ct);
+        return mapper.GetAdminPatchUserResult(result);
+    }
+
+    internal static async Task<IResult> DeleteUserAsync(
+        Guid userId,
+        ClaimsPrincipal caller,
+        IAdminUserService adminUsers,
+        IAuthResponseMapper mapper,
+        CancellationToken ct)
+    {
+        if (!Guid.TryParse(caller.FindFirstValue(ClaimTypes.NameIdentifier), out var callerId))
+            return Results.Unauthorized();
+
+        var result = await adminUsers.DeleteAsync(callerId, userId, ct);
+        return mapper.GetAdminDeleteUserResult(result);
+    }
 }
 
 public sealed record CreateAdminUserRequest(string Username, string Email);
 public sealed record AdminCreatedUserResponse(Guid Id, string Username, string Email, string TemporaryPassword);
 public sealed record AdminPasswordResetResponse(string TemporaryPassword);
+public sealed record AdminUserResponse(Guid Id, string Username, string Email, bool IsAdmin, bool IsDisabled, int StorageConfigCount);
+public sealed record PatchAdminUserRequest(bool? IsAdmin, bool? IsDisabled);

--- a/src/Anichron.API/Endpoints/AuthResponseMapper.cs
+++ b/src/Anichron.API/Endpoints/AuthResponseMapper.cs
@@ -207,7 +207,7 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
         => result.Error switch
         {
             AuthError.UserNotFound => Results.NotFound(),
-            AuthError.CannotModifySelf => Results.BadRequest(new { error = AuthMessages.CannotModifySelf }),
+            AuthError.CannotModifySelf => Results.Json(new { error = AuthMessages.CannotModifySelf }, statusCode: StatusCodes.Status403Forbidden),
             null => Results.Ok(ToAdminUserResponse(result.Value!)),
             AuthError.None or
             AuthError.UsernameTaken or
@@ -230,7 +230,7 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
         => result.Error switch
         {
             AuthError.UserNotFound => Results.NotFound(),
-            AuthError.CannotModifySelf => Results.BadRequest(new { error = AuthMessages.CannotModifySelf }),
+            AuthError.CannotModifySelf => Results.Json(new { error = AuthMessages.CannotModifySelf }, statusCode: StatusCodes.Status403Forbidden),
             null => Results.NoContent(),
             AuthError.None or
             AuthError.UsernameTaken or

--- a/src/Anichron.API/Endpoints/AuthResponseMapper.cs
+++ b/src/Anichron.API/Endpoints/AuthResponseMapper.cs
@@ -1,6 +1,7 @@
 using Anichron.API.Infrastructure;
 using Anichron.API.Services;
 using Anichron.API.Settings;
+using Anichron.Core.Domain;
 using System.Diagnostics;
 using static System.Globalization.CultureInfo;
 
@@ -14,6 +15,10 @@ public interface IAuthResponseMapper
     IResult GetChangePasswordResult(AuthResult result, PasswordPolicy passwordPolicy);
     IResult GetAdminCreateUserResult(AuthResult<AdminCreatedUser> result);
     IResult GetAdminResetPasswordResult(AdminUserPasswordReset? result);
+    IResult GetAdminGetUsersResult(List<User> users);
+    IResult GetAdminGetUserResult(User? user);
+    IResult GetAdminPatchUserResult(AuthResult<User> result);
+    IResult GetAdminDeleteUserResult(AuthResult result);
     void ClearRefreshCookie(HttpContext http);
 }
 
@@ -38,7 +43,9 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.InvalidCredentials or
                 AuthError.TokenInvalid or
                 AuthError.AccountDisabled or
-                AuthError.AccountTemporarilyLocked
+                AuthError.AccountTemporarilyLocked or
+                AuthError.CannotModifySelf or
+                AuthError.UserNotFound
                     => throw new UnreachableException($"Unexpected AuthError in Register: {result.Error}"),
                 _ => throw new UnreachableException($"Unhandled AuthError in Register: {result.Error}"),
             };
@@ -71,7 +78,9 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.PasswordTooShort or
                 AuthError.PasswordTooLong or
                 AuthError.PasswordPwned or
-                AuthError.InviteTokenInvalid
+                AuthError.InviteTokenInvalid or
+                AuthError.CannotModifySelf or
+                AuthError.UserNotFound
                     => throw new UnreachableException($"Unexpected AuthError in Login: {result.Error}"),
                 _ => throw new UnreachableException($"Unhandled AuthError in Login: {result.Error}"),
             };
@@ -103,7 +112,9 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.PasswordTooShort or
                 AuthError.PasswordTooLong or
                 AuthError.PasswordPwned or
-                AuthError.InviteTokenInvalid
+                AuthError.InviteTokenInvalid or
+                AuthError.CannotModifySelf or
+                AuthError.UserNotFound
                     => throw new UnreachableException($"Unexpected AuthError in Refresh: {result.Error}"),
                 _ => throw new UnreachableException($"Unhandled AuthError in Refresh: {result.Error}"),
             };
@@ -140,7 +151,9 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
             AuthError.InvalidEmail or
             AuthError.AccountDisabled or
             AuthError.AccountTemporarilyLocked or
-            AuthError.InviteTokenInvalid
+            AuthError.InviteTokenInvalid or
+            AuthError.CannotModifySelf or
+            AuthError.UserNotFound
                 => throw new UnreachableException($"Unexpected AuthError in ChangePassword: {result.Error}"),
             _ => throw new UnreachableException($"Unhandled AuthError in ChangePassword: {result.Error}"),
         };
@@ -165,7 +178,9 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
                 AuthError.PasswordPwned or
                 AuthError.AccountDisabled or
                 AuthError.AccountTemporarilyLocked or
-                AuthError.InviteTokenInvalid
+                AuthError.InviteTokenInvalid or
+                AuthError.CannotModifySelf or
+                AuthError.UserNotFound
                     => throw new UnreachableException($"Unexpected AuthError in AdminCreateUser: {result.Error}"),
                 _ => throw new UnreachableException($"Unhandled AuthError in AdminCreateUser: {result.Error}"),
             };
@@ -182,8 +197,63 @@ public sealed class AuthResponseMapper(AuthCookieSettings cookieSettings, IClock
             ? Results.NotFound()
             : Results.Ok(new AdminPasswordResetResponse(result.TemporaryPassword));
 
+    public IResult GetAdminGetUsersResult(List<User> users)
+        => Results.Ok(users.ConvertAll(ToAdminUserResponse));
+
+    public IResult GetAdminGetUserResult(User? user)
+        => user is null ? Results.NotFound() : Results.Ok(ToAdminUserResponse(user));
+
+    public IResult GetAdminPatchUserResult(AuthResult<User> result)
+        => result.Error switch
+        {
+            AuthError.UserNotFound => Results.NotFound(),
+            AuthError.CannotModifySelf => Results.BadRequest(new { error = AuthMessages.CannotModifySelf }),
+            null => Results.Ok(ToAdminUserResponse(result.Value!)),
+            AuthError.None or
+            AuthError.UsernameTaken or
+            AuthError.EmailTaken or
+            AuthError.InvalidCredentials or
+            AuthError.TokenInvalid or
+            AuthError.InvalidUsername or
+            AuthError.InvalidEmail or
+            AuthError.PasswordTooShort or
+            AuthError.PasswordTooLong or
+            AuthError.PasswordPwned or
+            AuthError.AccountDisabled or
+            AuthError.AccountTemporarilyLocked or
+            AuthError.InviteTokenInvalid
+                => throw new UnreachableException($"Unexpected AuthError in AdminPatchUser: {result.Error}"),
+            _ => throw new UnreachableException($"Unhandled AuthError in AdminPatchUser: {result.Error}"),
+        };
+
+    public IResult GetAdminDeleteUserResult(AuthResult result)
+        => result.Error switch
+        {
+            AuthError.UserNotFound => Results.NotFound(),
+            AuthError.CannotModifySelf => Results.BadRequest(new { error = AuthMessages.CannotModifySelf }),
+            null => Results.NoContent(),
+            AuthError.None or
+            AuthError.UsernameTaken or
+            AuthError.EmailTaken or
+            AuthError.InvalidCredentials or
+            AuthError.TokenInvalid or
+            AuthError.InvalidUsername or
+            AuthError.InvalidEmail or
+            AuthError.PasswordTooShort or
+            AuthError.PasswordTooLong or
+            AuthError.PasswordPwned or
+            AuthError.AccountDisabled or
+            AuthError.AccountTemporarilyLocked or
+            AuthError.InviteTokenInvalid
+                => throw new UnreachableException($"Unexpected AuthError in AdminDeleteUser: {result.Error}"),
+            _ => throw new UnreachableException($"Unhandled AuthError in AdminDeleteUser: {result.Error}"),
+        };
+
     public void ClearRefreshCookie(HttpContext http)
         => http.Response.Cookies.Delete(AuthMessages.RefreshTokenCookieName);
+
+    private static AdminUserResponse ToAdminUserResponse(User user)
+        => new(user.Id, user.Username, user.Email, user.IsAdmin, user.IsDisabled, user.StorageConfigs.Count);
 
     private IResult BuildTokenResponse(AuthTokens tokens, HttpContext http, bool setCookie)
     {

--- a/src/Anichron.API/Infrastructure/AuthMessages.cs
+++ b/src/Anichron.API/Infrastructure/AuthMessages.cs
@@ -16,6 +16,7 @@ internal static class AuthMessages
     internal const string TooManyRequests = "Too many requests. Please try again later.";
     internal const string RefreshTokenCookieName = "refresh_token";
     internal const string InviteTokenInvalid = "The invite token is invalid, expired, or has already been used.";
+    internal const string CannotModifySelf = "You cannot modify your own account.";
 }
 
 internal static class AuthRateLimitPolicies

--- a/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Anichron.API/Infrastructure/ServiceCollectionExtensions.cs
@@ -127,6 +127,7 @@ public static class ServiceCollectionExtensions
             services.AddScoped<IAuthService, AuthService>();
             services.AddTransient<IBootstrapSeeder, BootstrapSeeder>();
             services.AddScoped<IAdminResetService, AdminResetService>();
+            services.AddScoped<IAdminUserService, AdminUserService>();
             services.AddTransient<IBootstrapResetService, BootstrapResetService>();
 
             // SameSite=None is required when the UI and API are on different origins so browsers

--- a/src/Anichron.API/Services/AdminUserService.cs
+++ b/src/Anichron.API/Services/AdminUserService.cs
@@ -1,0 +1,67 @@
+using Anichron.Core.Data;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+
+namespace Anichron.API.Services;
+
+public interface IAdminUserService
+{
+    Task<List<User>> GetAllAsync(CancellationToken ct);
+    Task<User?> GetByIdAsync(Guid id, CancellationToken ct);
+    Task<AuthResult<User>> UpdateAsync(Guid callerId, Guid targetId, bool? isAdmin, bool? isDisabled, CancellationToken ct);
+    Task<AuthResult> DeleteAsync(Guid callerId, Guid targetId, CancellationToken ct);
+}
+
+public sealed class AdminUserService(
+    IUserRepository users,
+    IUnitOfWork unitOfWork,
+    IClock clock,
+    ITokenService tokenService) : IAdminUserService
+{
+    public Task<List<User>> GetAllAsync(CancellationToken ct)
+        => users.GetAllAsync(ct);
+
+    public Task<User?> GetByIdAsync(Guid id, CancellationToken ct)
+        => users.FindByIdWithConfigsAsync(id, ct);
+
+    public async Task<AuthResult<User>> UpdateAsync(Guid callerId, Guid targetId, bool? isAdmin, bool? isDisabled, CancellationToken ct)
+    {
+        if (callerId == targetId)
+            return AuthResult.Fail<User>(AuthError.CannotModifySelf);
+
+        var user = await users.FindByIdWithConfigsAsync(targetId, ct);
+        if (user is null)
+            return AuthResult.Fail<User>(AuthError.UserNotFound);
+
+        if (!isAdmin.HasValue && !isDisabled.HasValue)
+            return AuthResult.Ok(user);
+
+        if (isAdmin.HasValue)
+            user.IsAdmin = isAdmin.Value;
+
+        var shouldRevokeSessions = isDisabled == true && !user.IsDisabled;
+        if (isDisabled.HasValue)
+            user.IsDisabled = isDisabled.Value;
+
+        if (shouldRevokeSessions)
+            await tokenService.MarkAllSessionsRevokedAsync(targetId, clock.GetCurrentInstant(), ct);
+
+        await unitOfWork.SaveChangesAsync(ct);
+        return AuthResult.Ok(user);
+    }
+
+    public async Task<AuthResult> DeleteAsync(Guid callerId, Guid targetId, CancellationToken ct)
+    {
+        if (callerId == targetId)
+            return AuthResult.Fail(AuthError.CannotModifySelf);
+
+        var user = await users.FindByIdAsync(targetId, ct);
+        if (user is null)
+            return AuthResult.Fail(AuthError.UserNotFound);
+
+        await tokenService.MarkAllSessionsRevokedAsync(targetId, clock.GetCurrentInstant(), ct);
+        users.Remove(user);
+        await unitOfWork.SaveChangesAsync(ct);
+        return AuthResult.Ok();
+    }
+}

--- a/src/Anichron.API/Services/AuthService.cs
+++ b/src/Anichron.API/Services/AuthService.cs
@@ -28,6 +28,8 @@ public enum AuthError
     AccountDisabled = 10,
     AccountTemporarilyLocked = 11,
     InviteTokenInvalid = 12,
+    CannotModifySelf = 13,
+    UserNotFound = 14,
 }
 
 public sealed record AuthResult<T>

--- a/src/Anichron.Core.Tests.Unit/Data/Repository/UserRepositoryTests.cs
+++ b/src/Anichron.Core.Tests.Unit/Data/Repository/UserRepositoryTests.cs
@@ -1,0 +1,149 @@
+using Anichron.Core.Data;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anichron.Core.Tests.Unit.Data.Repository;
+
+public sealed class UserRepositoryTests
+{
+    private static AnichronDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AnichronDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AnichronDbContext(options);
+    }
+
+    private static User MakeUser(string username = "alice", string email = "alice@example.com")
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            Username = username,
+            Email = email,
+            PasswordHash = "hash",
+        };
+
+    // ==========================================================================
+    // GetAllAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task GetAllAsync_NoUsers_ReturnsEmptyList()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var repo = new EfUserRepository(db);
+
+        var result = await repo.GetAllAsync(ct);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetAllAsync_WithUsers_ReturnsAllUsers()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user1 = MakeUser("alice", "alice@example.com");
+        var user2 = MakeUser("bob", "bob@example.com");
+        await db.AddRangeAsync(user1, user2);
+        await db.SaveChangesAsync(ct);
+        var repo = new EfUserRepository(db);
+
+        var result = await repo.GetAllAsync(ct);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain(u => u.Id == user1.Id);
+        result.Should().Contain(u => u.Id == user2.Id);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_IncludesStorageConfigs()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = user.Id, RootPath = "/nas" };
+        db.StorageConfigs.Add(config);
+        await db.SaveChangesAsync(ct);
+        var repo = new EfUserRepository(db);
+
+        var result = await repo.GetAllAsync(ct);
+
+        result.Should().ContainSingle().Which.StorageConfigs.Should().ContainSingle(c => c.Id == config.Id);
+    }
+
+    // ==========================================================================
+    // FindByIdWithConfigsAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindByIdWithConfigsAsync_UserExists_ReturnsUser()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var repo = new EfUserRepository(db);
+
+        var result = await repo.FindByIdWithConfigsAsync(user.Id, ct);
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task FindByIdWithConfigsAsync_UserNotFound_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var repo = new EfUserRepository(db);
+
+        var result = await repo.FindByIdWithConfigsAsync(Guid.NewGuid(), ct);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindByIdWithConfigsAsync_IncludesStorageConfigs()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = user.Id, RootPath = "/nas" };
+        db.StorageConfigs.Add(config);
+        await db.SaveChangesAsync(ct);
+        var repo = new EfUserRepository(db);
+
+        var result = await repo.FindByIdWithConfigsAsync(user.Id, ct);
+
+        result!.StorageConfigs.Should().ContainSingle(c => c.Id == config.Id);
+    }
+
+    // ==========================================================================
+    // Remove
+    // ==========================================================================
+
+    [Fact]
+    public async Task Remove_ExistingUser_UserAbsentAfterSave()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var repo = new EfUserRepository(db);
+
+        repo.Remove(user);
+        await db.SaveChangesAsync(ct);
+
+        var found = await repo.FindByIdWithConfigsAsync(user.Id, ct);
+        found.Should().BeNull();
+    }
+}

--- a/src/Anichron.Core/Data/AnichronDbContext.cs
+++ b/src/Anichron.Core/Data/AnichronDbContext.cs
@@ -141,7 +141,7 @@ public class AnichronDbContext(DbContextOptions<AnichronDbContext> options) : Db
             entity.HasOne(i => i.CreatedBy)
                   .WithMany()
                   .HasForeignKey(i => i.CreatedByUserId)
-                  .OnDelete(DeleteBehavior.Restrict);
+                  .OnDelete(DeleteBehavior.SetNull);
 
             entity.HasOne(i => i.UsedBy)
                   .WithMany()

--- a/src/Anichron.Core/Data/Repository/UserRepository.cs
+++ b/src/Anichron.Core/Data/Repository/UserRepository.cs
@@ -12,7 +12,10 @@ public interface IUserRepository
     Task<User?> FindByCredentialAsync(string normalizedCredential, CancellationToken ct);
     Task<User?> FindAdminByUsernameAsync(string username, CancellationToken ct);
     Task<List<User>> FindAdminsAsync(int take, CancellationToken ct);
+    Task<List<User>> GetAllAsync(CancellationToken ct);
+    Task<User?> FindByIdWithConfigsAsync(Guid id, CancellationToken ct);
     void Add(User user);
+    void Remove(User user);
 }
 
 public sealed class EfUserRepository(AnichronDbContext db) : IUserRepository
@@ -39,6 +42,15 @@ public sealed class EfUserRepository(AnichronDbContext db) : IUserRepository
     public Task<List<User>> FindAdminsAsync(int take, CancellationToken ct)
         => db.Users.Where(u => u.IsAdmin).Take(take).ToListAsync(ct);
 
+    public Task<List<User>> GetAllAsync(CancellationToken ct)
+        => db.Users.Include(u => u.StorageConfigs).ToListAsync(ct);
+
+    public Task<User?> FindByIdWithConfigsAsync(Guid id, CancellationToken ct)
+        => db.Users.Include(u => u.StorageConfigs).FirstOrDefaultAsync(u => u.Id == id, ct);
+
     public void Add(User user)
         => db.Users.Add(user);
+
+    public void Remove(User user)
+        => db.Users.Remove(user);
 }

--- a/src/Anichron.Core/Domain/Invite.cs
+++ b/src/Anichron.Core/Domain/Invite.cs
@@ -7,8 +7,8 @@ public class Invite
     public Instant CreatedAt { get; set; }
     public Instant ExpiresAt { get; set; }
     public Instant? UsedAt { get; set; }
-    public Guid CreatedByUserId { get; set; }
+    public Guid? CreatedByUserId { get; set; }
     public Guid? UsedByUserId { get; set; }
-    public virtual User CreatedBy { get; set; } = null!;
+    public virtual User? CreatedBy { get; set; }
     public virtual User? UsedBy { get; set; }
 }

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
@@ -91,7 +91,7 @@ namespace Anichron.Core.Migrations
                     b.Property<Instant>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("CreatedByUserId")
+                    b.Property<Guid?>("CreatedByUserId")
                         .HasColumnType("uuid");
 
                     b.Property<Instant>("ExpiresAt")
@@ -400,8 +400,7 @@ namespace Anichron.Core.Migrations
                     b.HasOne("Anichron.Core.Domain.User", "CreatedBy")
                         .WithMany()
                         .HasForeignKey("CreatedByUserId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("Anichron.Core.Domain.User", "UsedBy")
                         .WithMany()

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
@@ -40,7 +40,7 @@ namespace Anichron.Core.Migrations
                     CreatedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
                     ExpiresAt = table.Column<Instant>(type: "timestamp with time zone", nullable: false),
                     UsedAt = table.Column<Instant>(type: "timestamp with time zone", nullable: true),
-                    CreatedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CreatedByUserId = table.Column<Guid>(type: "uuid", nullable: true),
                     UsedByUserId = table.Column<Guid>(type: "uuid", nullable: true)
                 },
                 constraints: table =>
@@ -51,7 +51,7 @@ namespace Anichron.Core.Migrations
                         column: x => x.CreatedByUserId,
                         principalTable: "Users",
                         principalColumn: "Id",
-                        onDelete: ReferentialAction.Restrict);
+                        onDelete: ReferentialAction.SetNull);
                     table.ForeignKey(
                         name: "FK_Invites_Users_UsedByUserId",
                         column: x => x.UsedByUserId,

--- a/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
+++ b/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
@@ -57,7 +57,7 @@ namespace Anichron.Core.Migrations
                     b.HasIndex("UserId", "AssetId")
                         .IsUnique();
 
-                    b.ToTable("Interactions");
+                    b.ToTable("Interactions", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.Burst", b =>
@@ -76,7 +76,7 @@ namespace Anichron.Core.Migrations
 
                     b.HasIndex("PrimaryAssetId");
 
-                    b.ToTable("Bursts");
+                    b.ToTable("Bursts", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.Invite", b =>
@@ -88,7 +88,7 @@ namespace Anichron.Core.Migrations
                     b.Property<Instant>("CreatedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<Guid>("CreatedByUserId")
+                    b.Property<Guid?>("CreatedByUserId")
                         .HasColumnType("uuid");
 
                     b.Property<Instant>("ExpiresAt")
@@ -120,7 +120,7 @@ namespace Anichron.Core.Migrations
 
                     b.HasIndex("UsedByUserId");
 
-                    b.ToTable("Invites");
+                    b.ToTable("Invites", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.MediaAsset", b =>
@@ -190,7 +190,7 @@ namespace Anichron.Core.Migrations
                     b.HasIndex("StorageConfigId", "FilePath")
                         .IsUnique();
 
-                    b.ToTable("MediaAssets");
+                    b.ToTable("MediaAssets", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.Metadata", b =>
@@ -227,7 +227,7 @@ namespace Anichron.Core.Migrations
 
                     b.HasKey("AssetId");
 
-                    b.ToTable("Metadata");
+                    b.ToTable("Metadata", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.ProxyFile", b =>
@@ -257,7 +257,7 @@ namespace Anichron.Core.Migrations
 
                     b.HasIndex("AssetId");
 
-                    b.ToTable("ProxyFiles");
+                    b.ToTable("ProxyFiles", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.RefreshToken", b =>
@@ -289,7 +289,7 @@ namespace Anichron.Core.Migrations
 
                     b.HasIndex("UserId", "ExpiresAt");
 
-                    b.ToTable("RefreshTokens");
+                    b.ToTable("RefreshTokens", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.User", b =>
@@ -333,7 +333,7 @@ namespace Anichron.Core.Migrations
                     b.HasIndex("Username")
                         .IsUnique();
 
-                    b.ToTable("Users");
+                    b.ToTable("Users", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.UserStorageConfig", b =>
@@ -359,7 +359,7 @@ namespace Anichron.Core.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("StorageConfigs");
+                    b.ToTable("StorageConfigs", (string)null);
                 });
 
             modelBuilder.Entity("Anichron.Core.Domain.AssetInteraction", b =>
@@ -397,8 +397,7 @@ namespace Anichron.Core.Migrations
                     b.HasOne("Anichron.Core.Domain.User", "CreatedBy")
                         .WithMany()
                         .HasForeignKey("CreatedByUserId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.HasOne("Anichron.Core.Domain.User", "UsedBy")
                         .WithMany()


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/users`, `GET /api/v1/users/{id}`, `PATCH /api/v1/users/{id}`, and `DELETE /api/v1/users/{id}` admin endpoints
- Introduces `IAdminUserService` / `AdminUserService` with self-modification guard (`CannotModifySelf`) and session revocation on disable/delete
- Extends `IUserRepository` with `GetAllAsync`, `FindByIdWithConfigsAsync`, and `Remove`; adds `CannotModifySelf = 13` and `UserNotFound = 14` to `AuthError`

## Test plan

- [ ] `AdminUserServiceTests` — 12 tests covering GetAll, GetById, Update (self-mod guard, not-found, isAdmin toggle, disable session-revocation transitions), Delete (self-delete guard, not-found, cascade)
- [ ] `AdminUserEndpointsTests` — 6 tests covering all 4 handlers including missing-claim → 401 short-circuit
- [ ] `AuthResponseMapperTests` — new tests for `GetAdminGetUsersResult`, `GetAdminGetUserResult`, `GetAdminPatchUserResult`, `GetAdminDeleteUserResult` including `UnreachableException` arms
- [ ] `UserRepositoryTests` — coverage for the three new repository methods

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)