### PR TITLE
feat(worker): Ingestion pipeline setup

### DIFF
--- a/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
@@ -1,0 +1,241 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Crawling;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Pipeline;
+using Anichron.Worker.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace Anichron.Worker.Tests.Unit.Crawling;
+
+public sealed class FileIngestionPipelineTests
+{
+    private static UserStorageConfig MakeConfig(string rootPath = "/nas") => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = Guid.NewGuid(),
+        RootPath = rootPath,
+    };
+
+    private sealed class TestFixture
+    {
+        public MockFileSystem FileSystem { get; } = new();
+        public List<IngestionContext> ProcessedContexts { get; } = [];
+        public List<IIngestionMiddleware> Middlewares { get; } = [];
+
+        public FileIngestionPipeline Build(int maxConcurrentFiles = 2)
+        {
+            var capturingMiddleware = Substitute.For<IIngestionMiddleware>();
+            capturingMiddleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(true);
+            capturingMiddleware.InvokeAsync(
+                    Arg.Any<IngestionContext>(),
+                    Arg.Any<IngestionDelegate>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    lock (ProcessedContexts)
+                        ProcessedContexts.Add(callInfo.ArgAt<IngestionContext>(0));
+                    return Task.CompletedTask;
+                });
+
+            Middlewares.Add(capturingMiddleware);
+
+            var options = Options.Create(new WorkerSettings { MaxConcurrentFiles = maxConcurrentFiles });
+            return new FileIngestionPipeline(
+                Middlewares,
+                FileSystem,
+                new LivePhotoLinker(FileSystem),
+                options,
+                Substitute.For<ILogger<FileIngestionPipeline>>());
+        }
+    }
+
+    // ==========================================================================
+    // Live Photo pairing — producer
+    // ==========================================================================
+
+    [Fact]
+    public async Task RunAsync_HeicWithMatchingMovSibling_EnqueuesLivePhotoPairItemAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/IMG_0001.HEIC", new MockFileData([]));
+        fixture.FileSystem.AddFile("/nas/IMG_0001.MOV", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        fixture.ProcessedContexts.Should().ContainSingle()
+            .Which.Item.Should().BeOfType<LivePhotoPairItem>();
+    }
+
+    [Fact]
+    public async Task RunAsync_HeicWithMatchingMovSibling_PairItemContainsCorrectPathsAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/IMG_0001.HEIC", new MockFileData([]));
+        fixture.FileSystem.AddFile("/nas/IMG_0001.MOV", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        var pair = fixture.ProcessedContexts.Single().Item.Should()
+            .BeOfType<LivePhotoPairItem>().Subject;
+        pair.AbsolutePath.Should().Be("/nas/IMG_0001.HEIC");
+        pair.MovAbsolutePath.Should().Be("/nas/IMG_0001.MOV");
+    }
+
+    [Fact]
+    public async Task RunAsync_HeicWithoutMovSibling_EnqueuesSingleFileItemAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/photo.HEIC", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        fixture.ProcessedContexts.Should().ContainSingle()
+            .Which.Item.Should().BeOfType<SingleFileItem>();
+    }
+
+    [Fact]
+    public async Task RunAsync_PairedMovFile_IsNotEnqueuedAsSeparateSingleFileItemAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/IMG_0001.HEIC", new MockFileData([]));
+        fixture.FileSystem.AddFile("/nas/IMG_0001.MOV", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        fixture.ProcessedContexts.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RunAsync_MovWithoutHeicSibling_EnqueuesSingleFileItemAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/video.MOV", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        fixture.ProcessedContexts.Should().ContainSingle()
+            .Which.Item.Should().BeOfType<SingleFileItem>()
+            .Which.MediaType.Should().Be(MediaType.Video);
+    }
+
+    // ==========================================================================
+    // Unsupported file types
+    // ==========================================================================
+
+    [Fact]
+    public async Task RunAsync_UnsupportedFileExtension_IsSkippedAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/document.pdf", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        fixture.ProcessedContexts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunAsync_MixedSupportedAndUnsupported_OnlySupportedFilesAreProcessedAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/photo.jpg", new MockFileData([]));
+        fixture.FileSystem.AddFile("/nas/document.pdf", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        fixture.ProcessedContexts.Should().ContainSingle()
+            .Which.Item.Should().BeOfType<SingleFileItem>()
+            .Which.AbsolutePath.Should().Be("/nas/photo.jpg");
+    }
+
+    // ==========================================================================
+    // Consumer — PipelineConfigurationException propagates
+    // ==========================================================================
+
+    [Fact]
+    public async Task RunAsync_PipelineConfigurationException_PropagatesAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/photo.jpg", new MockFileData([]));
+
+        var failingMiddleware = Substitute.For<IIngestionMiddleware>();
+        failingMiddleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
+        failingMiddleware.OnCannotInvoke(Arg.Any<IngestionContext>())
+            .Returns(new IngestionStepError("required slot missing"));
+        fixture.Middlewares.Add(failingMiddleware);
+
+        var options = Options.Create(new WorkerSettings { MaxConcurrentFiles = 1 });
+        var pipeline = new FileIngestionPipeline(
+            fixture.Middlewares,
+            fixture.FileSystem,
+            new LivePhotoLinker(fixture.FileSystem),
+            options,
+            Substitute.For<ILogger<FileIngestionPipeline>>());
+
+        var act = async () => await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<PipelineConfigurationException>();
+    }
+
+    // ==========================================================================
+    // Relative paths
+    // ==========================================================================
+
+    [Fact]
+    public async Task RunAsync_SingleFileItem_RelativePathIsRelativeToRootPathAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/2024/summer/beach.jpg", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        var item = fixture.ProcessedContexts.Single().Item.Should()
+            .BeOfType<SingleFileItem>().Subject;
+        item.RelativePath.Should().Be("2024/summer/beach.jpg");
+    }
+
+    // ==========================================================================
+    // Cross-directory isolation
+    // ==========================================================================
+
+    [Fact]
+    public async Task RunAsync_SameBaseNameInDifferentDirectories_NotPairedAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddFile("/nas/a/IMG_0001.HEIC", new MockFileData([]));
+        fixture.FileSystem.AddFile("/nas/b/IMG_0001.MOV", new MockFileData([]));
+
+        var pipeline = fixture.Build();
+        await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        fixture.ProcessedContexts.Should().HaveCount(2);
+        fixture.ProcessedContexts.Should().AllSatisfy(context =>
+            context.Item.Should().BeOfType<SingleFileItem>());
+    }
+
+    // ==========================================================================
+    // Empty directory
+    // ==========================================================================
+
+    [Fact]
+    public async Task RunAsync_EmptyDirectory_CompletesWithoutExceptionAsync()
+    {
+        var fixture = new TestFixture();
+        fixture.FileSystem.AddDirectory("/nas");
+
+        var pipeline = fixture.Build();
+        var act = async () => await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        fixture.ProcessedContexts.Should().BeEmpty();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
@@ -238,4 +238,19 @@ public sealed class FileIngestionPipelineTests
         await act.Should().NotThrowAsync();
         fixture.ProcessedContexts.Should().BeEmpty();
     }
+
+    // ==========================================================================
+    // Producer exception
+    // ==========================================================================
+
+    [Fact]
+    public async Task RunAsync_RootDirectoryDoesNotExist_ThrowsDirectoryNotFoundExceptionAsync()
+    {
+        var fixture = new TestFixture();
+
+        var pipeline = fixture.Build();
+        var act = async () => await pipeline.RunAsync(MakeConfig("/nonexistent"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<DirectoryNotFoundException>();
+    }
 }

--- a/src/Anichron.Worker.Tests.Unit/Crawling/WorkerTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Crawling/WorkerTests.cs
@@ -17,7 +17,7 @@ public sealed class WorkerTests
         public IFileIngestionPipeline Pipeline { get; } = Substitute.For<IFileIngestionPipeline>();
         public WorkerState WorkerState { get; } = new();
 
-        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly IServiceScopeFactory scopeFactory;
 
         public TestFixture()
         {
@@ -25,8 +25,8 @@ public sealed class WorkerTests
             var scope = Substitute.For<IServiceScope>();
             scope.ServiceProvider.Returns(serviceProvider);
 
-            _scopeFactory = Substitute.For<IServiceScopeFactory>();
-            _scopeFactory.CreateScope().Returns(scope);
+            scopeFactory = Substitute.For<IServiceScopeFactory>();
+            scopeFactory.CreateScope().Returns(scope);
 
             serviceProvider.GetService(typeof(IUserStorageConfigRepository)).Returns(ConfigRepository);
 
@@ -38,7 +38,7 @@ public sealed class WorkerTests
 
         public CrawlingWorker Build()
             => new(
-                _scopeFactory,
+                scopeFactory,
                 WorkerState,
                 Pipeline,
                 Options.Create(new WorkerSettings()),

--- a/src/Anichron.Worker.Tests.Unit/Crawling/WorkerTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Crawling/WorkerTests.cs
@@ -1,0 +1,131 @@
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+using Anichron.Worker.Crawling;
+using Anichron.Worker.Settings;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using CrawlingWorker = Anichron.Worker.Crawling.Worker;
+
+namespace Anichron.Worker.Tests.Unit.Crawling;
+
+public sealed class WorkerTests
+{
+    private sealed class TestFixture
+    {
+        public IUserStorageConfigRepository ConfigRepository { get; } = Substitute.For<IUserStorageConfigRepository>();
+        public IFileIngestionPipeline Pipeline { get; } = Substitute.For<IFileIngestionPipeline>();
+        public WorkerState WorkerState { get; } = new();
+
+        private readonly IServiceScopeFactory _scopeFactory;
+
+        public TestFixture()
+        {
+            var serviceProvider = Substitute.For<IServiceProvider>();
+            var scope = Substitute.For<IServiceScope>();
+            scope.ServiceProvider.Returns(serviceProvider);
+
+            _scopeFactory = Substitute.For<IServiceScopeFactory>();
+            _scopeFactory.CreateScope().Returns(scope);
+
+            serviceProvider.GetService(typeof(IUserStorageConfigRepository)).Returns(ConfigRepository);
+
+            ConfigRepository.GetAllActiveAsync(Arg.Any<CancellationToken>())
+                .Returns([]);
+            ConfigRepository.GetActiveByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+                .Returns([]);
+        }
+
+        public CrawlingWorker Build()
+            => new(
+                _scopeFactory,
+                WorkerState,
+                Pipeline,
+                Options.Create(new WorkerSettings()),
+                Substitute.For<ILogger<CrawlingWorker>>());
+    }
+
+    // ==========================================================================
+    // All-user mode
+    // ==========================================================================
+
+    [Fact]
+    public async Task CrawlAllAsync_NoResolvedUserId_CallsGetAllActiveAsync()
+    {
+        var fixture = new TestFixture();
+        var crawlingWorker = fixture.Build();
+
+        await crawlingWorker.CrawlAllAsync(CancellationToken.None);
+
+        await fixture.ConfigRepository.Received(1).GetAllActiveAsync(Arg.Any<CancellationToken>());
+        await fixture.ConfigRepository.DidNotReceive()
+            .GetActiveByUserIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // Dedicated-user mode
+    // ==========================================================================
+
+    [Fact]
+    public async Task CrawlAllAsync_WithResolvedUserId_CallsGetActiveByUserIdAsync()
+    {
+        var fixture = new TestFixture();
+        var userId = Guid.NewGuid();
+        fixture.WorkerState.ResolvedUserId = userId;
+        var crawlingWorker = fixture.Build();
+
+        await crawlingWorker.CrawlAllAsync(CancellationToken.None);
+
+        await fixture.ConfigRepository.Received(1)
+            .GetActiveByUserIdAsync(userId, Arg.Any<CancellationToken>());
+        await fixture.ConfigRepository.DidNotReceive().GetAllActiveAsync(Arg.Any<CancellationToken>());
+    }
+
+    // ==========================================================================
+    // Pipeline invocation
+    // ==========================================================================
+
+    [Fact]
+    public async Task CrawlAllAsync_MultipleActiveConfigs_RunsPipelineForEachAsync()
+    {
+        var fixture = new TestFixture();
+        var configs = new List<UserStorageConfig>
+        {
+            new() { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/nas/a" },
+            new() { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/nas/b" },
+        };
+        fixture.ConfigRepository.GetAllActiveAsync(Arg.Any<CancellationToken>()).Returns(configs);
+        var crawlingWorker = fixture.Build();
+
+        await crawlingWorker.CrawlAllAsync(CancellationToken.None);
+
+        await fixture.Pipeline.Received(2)
+            .RunAsync(Arg.Any<UserStorageConfig>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CrawlAllAsync_NoActiveConfigs_PipelineIsNeverCalledAsync()
+    {
+        var fixture = new TestFixture();
+        var crawlingWorker = fixture.Build();
+
+        await crawlingWorker.CrawlAllAsync(CancellationToken.None);
+
+        await fixture.Pipeline.DidNotReceive()
+            .RunAsync(Arg.Any<UserStorageConfig>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CrawlAllAsync_ActiveConfig_RunsPipelineWithCorrectConfigAsync()
+    {
+        var fixture = new TestFixture();
+        var config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/nas/photos" };
+        fixture.ConfigRepository.GetAllActiveAsync(Arg.Any<CancellationToken>())
+            .Returns([config]);
+        var crawlingWorker = fixture.Build();
+
+        await crawlingWorker.CrawlAllAsync(CancellationToken.None);
+
+        await fixture.Pipeline.Received(1).RunAsync(config, Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/LivePhotoLinkerTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/LivePhotoLinkerTests.cs
@@ -1,0 +1,145 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion;
+
+public sealed class LivePhotoLinkerTests
+{
+    private static LivePhotoLinker MakeLinker(MockFileSystem? fileSystem = null)
+        => new(fileSystem ?? new MockFileSystem());
+
+    // ==========================================================================
+    // Live Photo pairing
+    // ==========================================================================
+
+    [Fact]
+    public void Link_HeicWithMatchingMovSibling_ReturnsPair()
+    {
+        var result = MakeLinker().Link(
+            ["/nas/IMG_0001.HEIC", "/nas/IMG_0001.MOV"],
+            "/nas");
+
+        result.Items.Should().ContainSingle()
+            .Which.Should().BeOfType<LivePhotoPairItem>();
+    }
+
+    [Fact]
+    public void Link_HeicWithMatchingMovSibling_PairContainsCorrectPaths()
+    {
+        var result = MakeLinker().Link(
+            ["/nas/IMG_0001.HEIC", "/nas/IMG_0001.MOV"],
+            "/nas");
+
+        var pair = result.Items.Single().Should().BeOfType<LivePhotoPairItem>().Subject;
+        pair.AbsolutePath.Should().Be("/nas/IMG_0001.HEIC");
+        pair.MovAbsolutePath.Should().Be("/nas/IMG_0001.MOV");
+    }
+
+    [Fact]
+    public void Link_HeicWithMatchingMovSibling_RelativePathsAreRelativeToRoot()
+    {
+        var result = MakeLinker().Link(
+            ["/nas/2024/IMG_0001.HEIC", "/nas/2024/IMG_0001.MOV"],
+            "/nas");
+
+        var pair = result.Items.Single().Should().BeOfType<LivePhotoPairItem>().Subject;
+        pair.RelativePath.Should().Be("2024/IMG_0001.HEIC");
+        pair.MovRelativePath.Should().Be("2024/IMG_0001.MOV");
+    }
+
+    [Fact]
+    public void Link_HeicWithMatchingMovSibling_BothPathsClaimed()
+    {
+        var result = MakeLinker().Link(
+            ["/nas/IMG_0001.HEIC", "/nas/IMG_0001.MOV"],
+            "/nas");
+
+        result.ClaimedPaths.Should().Contain("/nas/IMG_0001.HEIC");
+        result.ClaimedPaths.Should().Contain("/nas/IMG_0001.MOV");
+    }
+
+    [Fact]
+    public void Link_HeicWithoutMovSibling_ReturnsSingleImageItem()
+    {
+        var result = MakeLinker().Link(["/nas/photo.HEIC"], "/nas");
+
+        result.Items.Should().ContainSingle()
+            .Which.Should().BeOfType<SingleFileItem>()
+            .Which.MediaType.Should().Be(MediaType.Image);
+    }
+
+    [Fact]
+    public void Link_HeicWithoutMovSibling_HeicPathStillClaimed()
+    {
+        var result = MakeLinker().Link(["/nas/photo.HEIC"], "/nas");
+
+        result.ClaimedPaths.Should().Contain("/nas/photo.HEIC");
+    }
+
+    [Fact]
+    public void Link_MovWithoutHeicSibling_IsNotReturned()
+    {
+        var result = MakeLinker().Link(["/nas/video.MOV"], "/nas");
+
+        result.Items.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Link_MovWithoutHeicSibling_IsNotClaimed()
+    {
+        var result = MakeLinker().Link(["/nas/video.MOV"], "/nas");
+
+        result.ClaimedPaths.Should().NotContain("/nas/video.MOV");
+    }
+
+    // ==========================================================================
+    // Case-insensitive matching
+    // ==========================================================================
+
+    [Fact]
+    public void Link_LowercaseExtensions_PairsCorrectly()
+    {
+        var result = MakeLinker().Link(
+            ["/nas/IMG_0001.heic", "/nas/IMG_0001.mov"],
+            "/nas");
+
+        result.Items.Should().ContainSingle()
+            .Which.Should().BeOfType<LivePhotoPairItem>();
+    }
+
+    [Fact]
+    public void Link_MixedCaseExtensions_PairsCorrectly()
+    {
+        var result = MakeLinker().Link(
+            ["/nas/IMG_0001.HEIC", "/nas/IMG_0001.mov"],
+            "/nas");
+
+        result.Items.Should().ContainSingle()
+            .Which.Should().BeOfType<LivePhotoPairItem>();
+    }
+
+    // ==========================================================================
+    // Empty / non-HEIC files
+    // ==========================================================================
+
+    [Fact]
+    public void Link_EmptyDirectory_ReturnsEmptyResult()
+    {
+        var result = MakeLinker().Link([], "/nas");
+
+        result.Items.Should().BeEmpty();
+        result.ClaimedPaths.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Link_OnlyJpgFiles_ReturnsEmptyResultWithNoClaims()
+    {
+        var result = MakeLinker().Link(
+            ["/nas/photo.jpg", "/nas/other.mp4"],
+            "/nas");
+
+        result.Items.Should().BeEmpty();
+        result.ClaimedPaths.Should().BeEmpty();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/MediaTypeDetectorTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/MediaTypeDetectorTests.cs
@@ -1,0 +1,72 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion;
+
+public sealed class MediaTypeDetectorTests
+{
+    // ==========================================================================
+    // Image extensions
+    // ==========================================================================
+
+    [Theory]
+    [InlineData("/photo.jpg")]
+    [InlineData("/photo.jpeg")]
+    [InlineData("/photo.png")]
+    [InlineData("/photo.heic")]
+    [InlineData("/photo.heif")]
+    [InlineData("/photo.gif")]
+    [InlineData("/photo.webp")]
+    [InlineData("/photo.tiff")]
+    [InlineData("/photo.tif")]
+    [InlineData("/photo.bmp")]
+    public void Detect_ImageExtension_ReturnsImage(string filePath)
+    {
+        MediaTypeDetector.Detect(filePath).Should().Be(MediaType.Image);
+    }
+
+    // ==========================================================================
+    // Video extensions
+    // ==========================================================================
+
+    [Theory]
+    [InlineData("/video.mov")]
+    [InlineData("/video.mp4")]
+    [InlineData("/video.m4v")]
+    [InlineData("/video.avi")]
+    [InlineData("/video.mkv")]
+    [InlineData("/video.wmv")]
+    public void Detect_VideoExtension_ReturnsVideo(string filePath)
+    {
+        MediaTypeDetector.Detect(filePath).Should().Be(MediaType.Video);
+    }
+
+    // ==========================================================================
+    // Case insensitivity
+    // ==========================================================================
+
+    [Theory]
+    [InlineData("/photo.JPG", MediaType.Image)]
+    [InlineData("/photo.HEIC", MediaType.Image)]
+    [InlineData("/photo.Jpeg", MediaType.Image)]
+    [InlineData("/video.MOV", MediaType.Video)]
+    [InlineData("/video.Mp4", MediaType.Video)]
+    public void Detect_UppercaseExtension_ReturnsCorrectType(string filePath, MediaType expected)
+    {
+        MediaTypeDetector.Detect(filePath).Should().Be(expected);
+    }
+
+    // ==========================================================================
+    // Unknown extension
+    // ==========================================================================
+
+    [Theory]
+    [InlineData("/document.pdf")]
+    [InlineData("/archive.zip")]
+    [InlineData("/text.txt")]
+    [InlineData("/noextension")]
+    public void Detect_UnknownExtension_ReturnsNull(string filePath)
+    {
+        MediaTypeDetector.Detect(filePath).Should().BeNull();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/LoggingMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/LoggingMiddlewareTests.cs
@@ -113,16 +113,17 @@ public sealed class LoggingMiddlewareTests
         { await middleware.InvokeAsync(MakeContext(), nextAsync, CancellationToken.None); }
         catch (InvalidOperationException exception) { _ = exception; }
 
-        logger.Entries.Should().ContainSingle();
+        logger.Entries.Should().ContainSingle()
+            .Which.Message.Should().Contain("Ingesting");
     }
 
     private sealed class CapturingLogger : ILogger<LoggingMiddleware>
     {
-        private readonly List<(LogLevel Level, string Message)> _entries = [];
-        public IReadOnlyList<(LogLevel Level, string Message)> Entries => _entries;
+        private readonly List<(LogLevel Level, string Message)> entries = [];
+        public IReadOnlyList<(LogLevel Level, string Message)> Entries => entries;
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
-            Func<TState, Exception?, string> formatter) => _entries.Add((logLevel, formatter(state, exception)));
+            Func<TState, Exception?, string> formatter) => entries.Add((logLevel, formatter(state, exception)));
 
         public bool IsEnabled(LogLevel logLevel) => true;
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/LoggingMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/LoggingMiddlewareTests.cs
@@ -1,0 +1,130 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Middlewares;
+using Anichron.Worker.Ingestion.Pipeline;
+using Microsoft.Extensions.Logging;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Middlewares;
+
+public sealed class LoggingMiddlewareTests
+{
+    private static IngestionContext MakeContext(string absolutePath = "/abs/photo.jpg") => new()
+    {
+        Item = new SingleFileItem(absolutePath, "photo.jpg", MediaType.Image),
+        Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+    };
+
+    // ==========================================================================
+    // CanInvoke
+    // ==========================================================================
+
+    [Fact]
+    public void CanInvoke_Always_ReturnsTrue()
+    {
+        var middleware = new LoggingMiddleware(Substitute.For<ILogger<LoggingMiddleware>>());
+        middleware.CanInvoke(MakeContext()).Should().BeTrue();
+    }
+
+    // ==========================================================================
+    // InvokeAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_Always_CallsNextAsync()
+    {
+        var middleware = new LoggingMiddleware(Substitute.For<ILogger<LoggingMiddleware>>());
+        var nextCalled = false;
+        Task nextAsync(IngestionContext context, CancellationToken ct)
+        {
+            _ = (context, ct);
+            nextCalled = true;
+            return Task.CompletedTask;
+        }
+
+        await middleware.InvokeAsync(MakeContext(), nextAsync, CancellationToken.None);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenNextThrows_ExceptionPropagatesAsync()
+    {
+        var middleware = new LoggingMiddleware(Substitute.For<ILogger<LoggingMiddleware>>());
+        static Task nextAsync(IngestionContext context, CancellationToken ct)
+        {
+            _ = (context, ct);
+            throw new InvalidOperationException("downstream error");
+        }
+
+        var act = async () => await middleware.InvokeAsync(MakeContext(), nextAsync, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("downstream error");
+    }
+
+    // ==========================================================================
+    // Log output
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_Always_LogsStartMessageContainingPathAsync()
+    {
+        var logger = new CapturingLogger();
+        var middleware = new LoggingMiddleware(logger);
+        static Task nextAsync(IngestionContext context, CancellationToken ct)
+        {
+            _ = (context, ct);
+            return Task.CompletedTask;
+        }
+
+        await middleware.InvokeAsync(MakeContext("/abs/photo.jpg"), nextAsync, CancellationToken.None);
+
+        logger.Entries.Should().Contain(entry =>
+            entry.Level == LogLevel.Debug && entry.Message.Contains("/abs/photo.jpg"));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenNextCompletes_LogsCompletionMessageAsync()
+    {
+        var logger = new CapturingLogger();
+        var middleware = new LoggingMiddleware(logger);
+        static Task nextAsync(IngestionContext context, CancellationToken ct)
+        {
+            _ = (context, ct);
+            return Task.CompletedTask;
+        }
+
+        await middleware.InvokeAsync(MakeContext("/abs/photo.jpg"), nextAsync, CancellationToken.None);
+
+        logger.Entries.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_WhenNextThrows_OnlyLogsStartMessageAsync()
+    {
+        var logger = new CapturingLogger();
+        var middleware = new LoggingMiddleware(logger);
+        static Task nextAsync(IngestionContext context, CancellationToken ct)
+        {
+            _ = (context, ct);
+            throw new InvalidOperationException();
+        }
+
+        try
+        { await middleware.InvokeAsync(MakeContext(), nextAsync, CancellationToken.None); }
+        catch (InvalidOperationException exception) { _ = exception; }
+
+        logger.Entries.Should().ContainSingle();
+    }
+
+    private sealed class CapturingLogger : ILogger<LoggingMiddleware>
+    {
+        private readonly List<(LogLevel Level, string Message)> _entries = [];
+        public IReadOnlyList<(LogLevel Level, string Message)> Entries => _entries;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => _entries.Add((logLevel, formatter(state, exception)));
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
@@ -1,0 +1,129 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Pipeline;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Pipeline;
+
+public sealed class IngestionPipelineBuilderTests
+{
+    private static IngestionContext MakeContext() => new()
+    {
+        Item = new SingleFileItem("/abs/file.jpg", "file.jpg", MediaType.Image),
+        Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+    };
+
+    // ==========================================================================
+    // Build — ordering
+    // ==========================================================================
+
+    [Fact]
+    public async Task Build_MultipleMiddlewares_InvokesInRegistrationOrderAsync()
+    {
+        var order = new List<int>();
+
+        var first = Substitute.For<IIngestionMiddleware>();
+        first.CanInvoke(Arg.Any<IngestionContext>()).Returns(true);
+        first.InvokeAsync(Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                order.Add(1);
+                return callInfo.ArgAt<IngestionDelegate>(1)(callInfo.ArgAt<IngestionContext>(0), callInfo.ArgAt<CancellationToken>(2));
+            });
+
+        var second = Substitute.For<IIngestionMiddleware>();
+        second.CanInvoke(Arg.Any<IngestionContext>()).Returns(true);
+        second.InvokeAsync(Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                order.Add(2);
+                return callInfo.ArgAt<IngestionDelegate>(1)(callInfo.ArgAt<IngestionContext>(0), callInfo.ArgAt<CancellationToken>(2));
+            });
+
+        var pipeline = IngestionPipelineBuilder.Build([first, second]);
+        await pipeline(MakeContext(), CancellationToken.None);
+
+        order.Should().Equal(1, 2);
+    }
+
+    [Fact]
+    public async Task Build_EmptyPipeline_CompletesWithoutExceptionAsync()
+    {
+        var pipeline = IngestionPipelineBuilder.Build([]);
+        var act = async () => await pipeline(MakeContext(), CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    // ==========================================================================
+    // Build — CanInvoke guard
+    // ==========================================================================
+
+    [Fact]
+    public async Task Build_CanInvokeReturnsFalse_ThrowsPipelineConfigurationExceptionAsync()
+    {
+        var middleware = Substitute.For<IIngestionMiddleware>();
+        middleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
+        middleware.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError("hash is required"));
+
+        var pipeline = IngestionPipelineBuilder.Build([middleware]);
+        var act = async () => await pipeline(MakeContext(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<PipelineConfigurationException>()
+            .WithMessage("*hash is required*");
+    }
+
+    [Fact]
+    public async Task Build_CanInvokeReturnsFalse_ExceptionMessageContainsMiddlewareNameAsync()
+    {
+        var middleware = Substitute.For<IIngestionMiddleware>();
+        middleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
+        middleware.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError("missing"));
+
+        var pipeline = IngestionPipelineBuilder.Build([middleware]);
+        var act = async () => await pipeline(MakeContext(), CancellationToken.None);
+
+        await act.Should().ThrowAsync<PipelineConfigurationException>()
+            .WithMessage("*cannot invoke*");
+    }
+
+    [Fact]
+    public async Task Build_CanInvokeReturnsFalse_InvokeAsyncIsNeverCalledAsync()
+    {
+        var middleware = Substitute.For<IIngestionMiddleware>();
+        middleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
+        middleware.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError(string.Empty));
+
+        var pipeline = IngestionPipelineBuilder.Build([middleware]);
+        try
+        { await pipeline(MakeContext(), CancellationToken.None); }
+        catch (PipelineConfigurationException exception) { _ = exception; }
+
+        await middleware.DidNotReceive().InvokeAsync(
+            Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Build_SecondMiddlewareCannotInvoke_FirstMiddlewareStillRunsAsync()
+    {
+        var firstInvoked = false;
+
+        var first = Substitute.For<IIngestionMiddleware>();
+        first.CanInvoke(Arg.Any<IngestionContext>()).Returns(true);
+        first.InvokeAsync(Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                firstInvoked = true;
+                return callInfo.ArgAt<IngestionDelegate>(1)(callInfo.ArgAt<IngestionContext>(0), callInfo.ArgAt<CancellationToken>(2));
+            });
+
+        var second = Substitute.For<IIngestionMiddleware>();
+        second.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
+        second.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError(string.Empty));
+
+        var pipeline = IngestionPipelineBuilder.Build([first, second]);
+        try
+        { await pipeline(MakeContext(), CancellationToken.None); }
+        catch (PipelineConfigurationException exception) { _ = exception; }
+
+        firstInvoked.Should().BeTrue();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
@@ -20,24 +20,8 @@ public sealed class IngestionPipelineBuilderTests
     public async Task Build_MultipleMiddlewares_InvokesInRegistrationOrderAsync()
     {
         var order = new List<int>();
-
-        var first = Substitute.For<IIngestionMiddleware>();
-        first.CanInvoke(Arg.Any<IngestionContext>()).Returns(true);
-        first.InvokeAsync(Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                order.Add(1);
-                return callInfo.ArgAt<IngestionDelegate>(1)(callInfo.ArgAt<IngestionContext>(0), callInfo.ArgAt<CancellationToken>(2));
-            });
-
-        var second = Substitute.For<IIngestionMiddleware>();
-        second.CanInvoke(Arg.Any<IngestionContext>()).Returns(true);
-        second.InvokeAsync(Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                order.Add(2);
-                return callInfo.ArgAt<IngestionDelegate>(1)(callInfo.ArgAt<IngestionContext>(0), callInfo.ArgAt<CancellationToken>(2));
-            });
+        var first = new OrderCapturingMiddleware(1, order);
+        var second = new OrderCapturingMiddleware(2, order);
 
         var pipeline = IngestionPipelineBuilder.Build([first, second]);
         await pipeline(MakeContext(), CancellationToken.None);
@@ -104,16 +88,8 @@ public sealed class IngestionPipelineBuilderTests
     [Fact]
     public async Task Build_SecondMiddlewareCannotInvoke_FirstMiddlewareStillRunsAsync()
     {
-        var firstInvoked = false;
-
-        var first = Substitute.For<IIngestionMiddleware>();
-        first.CanInvoke(Arg.Any<IngestionContext>()).Returns(true);
-        first.InvokeAsync(Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                firstInvoked = true;
-                return callInfo.ArgAt<IngestionDelegate>(1)(callInfo.ArgAt<IngestionContext>(0), callInfo.ArgAt<CancellationToken>(2));
-            });
+        var invoked = new List<int>();
+        var first = new OrderCapturingMiddleware(1, invoked);
 
         var second = Substitute.For<IIngestionMiddleware>();
         second.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
@@ -124,6 +100,22 @@ public sealed class IngestionPipelineBuilderTests
         { await pipeline(MakeContext(), CancellationToken.None); }
         catch (PipelineConfigurationException exception) { _ = exception; }
 
-        firstInvoked.Should().BeTrue();
+        invoked.Should().Contain(1);
+    }
+
+    // ==========================================================================
+    // Helpers
+    // ==========================================================================
+
+    private sealed class OrderCapturingMiddleware(int order, List<int> tracker) : IIngestionMiddleware
+    {
+        public bool CanInvoke(IngestionContext context) => true;
+        public IngestionStepError OnCannotInvoke(IngestionContext context) => new(string.Empty);
+
+        public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
+        {
+            tracker.Add(order);
+            await next(context, ct);
+        }
     }
 }

--- a/src/Anichron.Worker.Tests.Unit/Maintenance/TokenCleanupServiceTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Maintenance/TokenCleanupServiceTests.cs
@@ -45,42 +45,42 @@ public sealed class TokenCleanupServiceTests
     // ==========================================================================
 
     [Fact]
-    public async Task RunCleanupAsync_CallsDeleteExpiredWithCurrentInstant()
+    public async Task RunCleanupAsync_CallsDeleteExpiredWithCurrentInstantAsync()
     {
-        var fx = new TestFixture();
-        var sut = fx.Build();
+        var fixture = new TestFixture();
+        var service = fixture.Build();
 
-        await sut.RunCleanupAsync(CancellationToken.None);
+        await service.RunCleanupAsync(CancellationToken.None);
 
-        await fx.Repository.Received(1).DeleteExpiredAsync(fx.Now, Arg.Any<CancellationToken>());
+        await fixture.Repository.Received(1).DeleteExpiredAsync(fixture.Now, Arg.Any<CancellationToken>());
     }
 
     [Theory]
     [InlineData(0)]
     [InlineData(42)]
-    public async Task RunCleanupAsync_LogsDeletedCountAtInformation(int deletedCount)
+    public async Task RunCleanupAsync_LogsDeletedCountAtInformationAsync(int deletedCount)
     {
-        var fx = new TestFixture();
-        fx.Repository.DeleteExpiredAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>()).Returns(deletedCount);
+        var fixture = new TestFixture();
+        fixture.Repository.DeleteExpiredAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>()).Returns(deletedCount);
         var logger = new CapturingLogger();
-        var sut = new TokenCleanupService(fx.ScopeFactory, fx.Clock, Options.Create(new WorkerSettings()), logger);
+        var service = new TokenCleanupService(fixture.ScopeFactory, fixture.Clock, Options.Create(new WorkerSettings()), logger);
 
-        await sut.RunCleanupAsync(CancellationToken.None);
+        await service.RunCleanupAsync(CancellationToken.None);
 
         logger.Entries.Should().ContainSingle()
             .Which.Should().Match<(LogLevel Level, string Message)>(
-                e => e.Level == LogLevel.Information && e.Message.Contains(deletedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+                entry => entry.Level == LogLevel.Information && entry.Message.Contains(deletedCount.ToString(System.Globalization.CultureInfo.InvariantCulture)));
     }
 
     [Fact]
-    public async Task RunCleanupAsync_PropagatesRepositoryException()
+    public async Task RunCleanupAsync_PropagatesRepositoryExceptionAsync()
     {
-        var fx = new TestFixture();
-        fx.Repository.DeleteExpiredAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>())
+        var fixture = new TestFixture();
+        fixture.Repository.DeleteExpiredAsync(Arg.Any<Instant>(), Arg.Any<CancellationToken>())
             .Returns<int>(_ => throw new InvalidOperationException("DB error"));
-        var sut = fx.Build();
+        var service = fixture.Build();
 
-        var act = async () => await sut.RunCleanupAsync(CancellationToken.None);
+        var act = async () => await service.RunCleanupAsync(CancellationToken.None);
 
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("DB error");
     }

--- a/src/Anichron.Worker.Tests.Unit/Startup/DatabaseMigratorServiceTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Startup/DatabaseMigratorServiceTests.cs
@@ -36,15 +36,15 @@ public sealed class DatabaseMigratorServiceTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_MigrationSucceedsFirstAttempt_ReturnsWithoutException()
+    public async Task StartAsync_MigrationSucceedsFirstAttempt_ReturnsWithoutExceptionAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
-        var sut = fx.Build();
+        var fixture = new TestFixture();
+        var service = fixture.Build();
 
-        await sut.StartAsync(ct);
+        await service.StartAsync(ct);
 
-        await fx.Migrator.Received(1).MigrateAsync(Arg.Any<CancellationToken>());
+        await fixture.Migrator.Received(1).MigrateAsync(Arg.Any<CancellationToken>());
     }
 
     // ==========================================================================
@@ -52,21 +52,21 @@ public sealed class DatabaseMigratorServiceTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_DatabaseNotReadyThenReady_RetriesAndSucceeds()
+    public async Task StartAsync_DatabaseNotReadyThenReady_RetriesAndSucceedsAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
+        var fixture = new TestFixture();
         var callCount = 0;
-        fx.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ =>
+        fixture.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ =>
         {
             callCount++;
             return callCount < 3 ? throw new InvalidOperationException("DB not ready yet") : Task.CompletedTask;
         });
-        var sut = fx.Build();
+        var service = fixture.Build();
 
-        await sut.StartAsync(ct);
+        await service.StartAsync(ct);
 
-        await fx.Migrator.Received(3).MigrateAsync(Arg.Any<CancellationToken>());
+        await fixture.Migrator.Received(3).MigrateAsync(Arg.Any<CancellationToken>());
     }
 
     // ==========================================================================
@@ -74,45 +74,45 @@ public sealed class DatabaseMigratorServiceTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_AllAttemptsExhausted_ThrowsInvalidOperationException()
+    public async Task StartAsync_AllAttemptsExhausted_ThrowsInvalidOperationExceptionAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
-        fx.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ => throw new InvalidOperationException("postgres unavailable"));
-        var sut = fx.Build();
+        var fixture = new TestFixture();
+        fixture.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ => throw new InvalidOperationException("postgres unavailable"));
+        var service = fixture.Build();
 
-        var act = async () => await sut.StartAsync(ct);
+        var act = async () => await service.StartAsync(ct);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*10 attempts*");
     }
 
     [Fact]
-    public async Task StartAsync_AllAttemptsExhausted_OriginalExceptionIsInnerException()
+    public async Task StartAsync_AllAttemptsExhausted_OriginalExceptionIsInnerExceptionAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
-        var originalEx = new InvalidOperationException("postgres unavailable");
-        fx.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ => throw originalEx);
-        var sut = fx.Build();
+        var fixture = new TestFixture();
+        var originalException = new InvalidOperationException("postgres unavailable");
+        fixture.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ => throw originalException);
+        var service = fixture.Build();
 
         var thrown = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => sut.StartAsync(ct));
+            () => service.StartAsync(ct));
 
-        thrown.InnerException.Should().BeSameAs(originalEx);
+        thrown.InnerException.Should().BeSameAs(originalException);
     }
 
     [Fact]
-    public async Task StartAsync_AllAttemptsExhausted_MigrateCalledMaxAttemptsTimes()
+    public async Task StartAsync_AllAttemptsExhausted_MigrateCalledMaxAttemptsTimesAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
-        fx.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ => throw new InvalidOperationException());
-        var sut = fx.Build();
+        var fixture = new TestFixture();
+        fixture.Migrator.MigrateAsync(Arg.Any<CancellationToken>()).Returns(_ => throw new InvalidOperationException());
+        var service = fixture.Build();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.StartAsync(ct));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.StartAsync(ct));
 
-        await fx.Migrator.Received(10).MigrateAsync(Arg.Any<CancellationToken>());
+        await fixture.Migrator.Received(10).MigrateAsync(Arg.Any<CancellationToken>());
     }
 
     // ==========================================================================
@@ -120,10 +120,10 @@ public sealed class DatabaseMigratorServiceTests
     // ==========================================================================
 
     [Fact]
-    public async Task StopAsync_AlwaysCompletesSuccessfully()
+    public async Task StopAsync_AlwaysCompletesSuccessfullyAsync()
     {
-        var sut = new TestFixture().Build();
-        var act = async () => await sut.StopAsync(TestContext.Current.CancellationToken);
+        var service = new TestFixture().Build();
+        var act = async () => await service.StopAsync(TestContext.Current.CancellationToken);
         await act.Should().NotThrowAsync();
     }
 }

--- a/src/Anichron.Worker.Tests.Unit/Startup/WorkerInitializerTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Startup/WorkerInitializerTests.cs
@@ -48,30 +48,30 @@ public sealed class WorkerInitializerTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_UserIsEmpty_LogsAllUserModeAndMakesNoDbCalls()
+    public async Task StartAsync_UserIsEmpty_LogsAllUserModeAndMakesNoDbCallsAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
-        var sut = fx.Build(user: string.Empty);
+        var fixture = new TestFixture();
+        var initializer = fixture.Build(user: string.Empty);
 
-        await sut.StartAsync(ct);
+        await initializer.StartAsync(ct);
 
-        await fx.UserRepository.DidNotReceive().FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await fx.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-        fx.WorkerState.ResolvedUserId.Should().BeNull();
+        await fixture.UserRepository.DidNotReceive().FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        fixture.WorkerState.ResolvedUserId.Should().BeNull();
     }
 
     [Fact]
-    public async Task StartAsync_UserIsWhitespace_LogsAllUserModeAndMakesNoDbCalls()
+    public async Task StartAsync_UserIsWhitespace_LogsAllUserModeAndMakesNoDbCallsAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
-        var sut = fx.Build(user: "   ");
+        var fixture = new TestFixture();
+        var initializer = fixture.Build(user: "   ");
 
-        await sut.StartAsync(ct);
+        await initializer.StartAsync(ct);
 
-        await fx.UserRepository.DidNotReceive().FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
-        fx.WorkerState.ResolvedUserId.Should().BeNull();
+        await fixture.UserRepository.DidNotReceive().FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        fixture.WorkerState.ResolvedUserId.Should().BeNull();
     }
 
     // ==========================================================================
@@ -79,15 +79,15 @@ public sealed class WorkerInitializerTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_UnknownUser_ThrowsInvalidOperationExceptionWithUserInMessage()
+    public async Task StartAsync_UnknownUser_ThrowsInvalidOperationExceptionWithUserInMessageAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
-        fx.UserRepository.FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+        var fixture = new TestFixture();
+        fixture.UserRepository.FindByCredentialAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((User?)null);
-        var sut = fx.Build(user: "ghost@example.com");
+        var initializer = fixture.Build(user: "ghost@example.com");
 
-        var act = async () => await sut.StartAsync(ct);
+        var act = async () => await initializer.StartAsync(ct);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*ghost@example.com*");
@@ -98,21 +98,21 @@ public sealed class WorkerInitializerTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_CredentialNormalized_TrimsAndLowercases()
+    public async Task StartAsync_CredentialNormalized_TrimsAndLowercasesAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
+        var fixture = new TestFixture();
         var user = new User { Id = Guid.NewGuid(), Username = "alice" };
-        fx.UserRepository.FindByCredentialAsync("alice@example.com", Arg.Any<CancellationToken>())
+        fixture.UserRepository.FindByCredentialAsync("alice@example.com", Arg.Any<CancellationToken>())
             .Returns(user);
         var existingConfig = new UserStorageConfig { Id = Guid.NewGuid(), UserId = user.Id, RootPath = "/data" };
-        fx.StorageConfigRepository.FindByRootPathAsync("/data", Arg.Any<CancellationToken>())
+        fixture.StorageConfigRepository.FindByRootPathAsync("/data", Arg.Any<CancellationToken>())
             .Returns(existingConfig);
-        var sut = fx.Build(user: "  Alice@Example.COM  ", rootPath: "/data");
+        var initializer = fixture.Build(user: "  Alice@Example.COM  ", rootPath: "/data");
 
-        await sut.StartAsync(ct);
+        await initializer.StartAsync(ct);
 
-        await fx.UserRepository.Received(1)
+        await fixture.UserRepository.Received(1)
             .FindByCredentialAsync("alice@example.com", Arg.Any<CancellationToken>());
     }
 
@@ -121,21 +121,21 @@ public sealed class WorkerInitializerTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_ExistingConfigSameUser_SkipsSaveAndSetsResolvedUserId()
+    public async Task StartAsync_ExistingConfigSameUser_SkipsSaveAndSetsResolvedUserIdAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
+        var fixture = new TestFixture();
         var user = new User { Id = Guid.NewGuid(), Username = "alice" };
         var existingConfig = new UserStorageConfig { Id = Guid.NewGuid(), UserId = user.Id, RootPath = "/nas" };
-        fx.UserRepository.FindByCredentialAsync("alice", Arg.Any<CancellationToken>()).Returns(user);
-        fx.StorageConfigRepository.FindByRootPathAsync("/nas", Arg.Any<CancellationToken>()).Returns(existingConfig);
-        var sut = fx.Build(user: "alice", rootPath: "/nas");
+        fixture.UserRepository.FindByCredentialAsync("alice", Arg.Any<CancellationToken>()).Returns(user);
+        fixture.StorageConfigRepository.FindByRootPathAsync("/nas", Arg.Any<CancellationToken>()).Returns(existingConfig);
+        var initializer = fixture.Build(user: "alice", rootPath: "/nas");
 
-        await sut.StartAsync(ct);
+        await initializer.StartAsync(ct);
 
-        fx.StorageConfigRepository.DidNotReceive().Add(Arg.Any<UserStorageConfig>());
-        await fx.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
-        fx.WorkerState.ResolvedUserId.Should().Be(user.Id);
+        fixture.StorageConfigRepository.DidNotReceive().Add(Arg.Any<UserStorageConfig>());
+        await fixture.UnitOfWork.DidNotReceive().SaveChangesAsync(Arg.Any<CancellationToken>());
+        fixture.WorkerState.ResolvedUserId.Should().Be(user.Id);
     }
 
     // ==========================================================================
@@ -143,17 +143,17 @@ public sealed class WorkerInitializerTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_ExistingConfigDifferentUser_ThrowsInvalidOperationExceptionWithRootPathInMessage()
+    public async Task StartAsync_ExistingConfigDifferentUser_ThrowsInvalidOperationExceptionWithRootPathInMessageAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
+        var fixture = new TestFixture();
         var user = new User { Id = Guid.NewGuid(), Username = "alice" };
         var conflictingConfig = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/shared" };
-        fx.UserRepository.FindByCredentialAsync("alice", Arg.Any<CancellationToken>()).Returns(user);
-        fx.StorageConfigRepository.FindByRootPathAsync("/shared", Arg.Any<CancellationToken>()).Returns(conflictingConfig);
-        var sut = fx.Build(user: "alice", rootPath: "/shared");
+        fixture.UserRepository.FindByCredentialAsync("alice", Arg.Any<CancellationToken>()).Returns(user);
+        fixture.StorageConfigRepository.FindByRootPathAsync("/shared", Arg.Any<CancellationToken>()).Returns(conflictingConfig);
+        var initializer = fixture.Build(user: "alice", rootPath: "/shared");
 
-        var act = async () => await sut.StartAsync(ct);
+        var act = async () => await initializer.StartAsync(ct);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*/shared*");
@@ -164,25 +164,25 @@ public sealed class WorkerInitializerTests
     // ==========================================================================
 
     [Fact]
-    public async Task StartAsync_NoExistingConfig_CreatesStorageConfigWithCorrectFieldsAndSetsResolvedUserId()
+    public async Task StartAsync_NoExistingConfig_CreatesStorageConfigWithCorrectFieldsAndSetsResolvedUserIdAsync()
     {
         var ct = TestContext.Current.CancellationToken;
-        var fx = new TestFixture();
+        var fixture = new TestFixture();
         var user = new User { Id = Guid.NewGuid(), Username = "alice" };
-        fx.UserRepository.FindByCredentialAsync("alice", Arg.Any<CancellationToken>()).Returns(user);
-        fx.StorageConfigRepository.FindByRootPathAsync("/nas", Arg.Any<CancellationToken>())
+        fixture.UserRepository.FindByCredentialAsync("alice", Arg.Any<CancellationToken>()).Returns(user);
+        fixture.StorageConfigRepository.FindByRootPathAsync("/nas", Arg.Any<CancellationToken>())
             .Returns((UserStorageConfig?)null);
-        var sut = fx.Build(user: "alice", rootPath: "/nas");
+        var initializer = fixture.Build(user: "alice", rootPath: "/nas");
 
-        await sut.StartAsync(ct);
+        await initializer.StartAsync(ct);
 
-        fx.StorageConfigRepository.Received(1).Add(
-            Arg.Is<UserStorageConfig>(c =>
-                c.UserId == user.Id &&
-                c.RootPath == "/nas" &&
-                c.IsActive));
-        await fx.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
-        fx.WorkerState.ResolvedUserId.Should().Be(user.Id);
+        fixture.StorageConfigRepository.Received(1).Add(
+            Arg.Is<UserStorageConfig>(storageConfig =>
+                storageConfig.UserId == user.Id &&
+                storageConfig.RootPath == "/nas" &&
+                storageConfig.IsActive));
+        await fixture.UnitOfWork.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+        fixture.WorkerState.ResolvedUserId.Should().Be(user.Id);
     }
 
     // ==========================================================================
@@ -190,10 +190,10 @@ public sealed class WorkerInitializerTests
     // ==========================================================================
 
     [Fact]
-    public async Task StopAsync_AlwaysCompletesSuccessfully()
+    public async Task StopAsync_AlwaysCompletesSuccessfullyAsync()
     {
-        var sut = new TestFixture().Build();
-        var act = async () => await sut.StopAsync(TestContext.Current.CancellationToken);
+        var initializer = new TestFixture().Build();
+        var act = async () => await initializer.StopAsync(TestContext.Current.CancellationToken);
         await act.Should().NotThrowAsync();
     }
 }

--- a/src/Anichron.Worker/Anichron.Worker.csproj
+++ b/src/Anichron.Worker/Anichron.Worker.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
+++ b/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
@@ -1,0 +1,128 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Pipeline;
+using Anichron.Worker.Settings;
+using Microsoft.Extensions.Options;
+using System.IO.Abstractions;
+using System.Threading.Channels;
+
+namespace Anichron.Worker.Crawling;
+
+internal interface IFileIngestionPipeline
+{
+    Task RunAsync(UserStorageConfig config, CancellationToken ct);
+}
+
+internal sealed partial class FileIngestionPipeline(
+    IEnumerable<IIngestionMiddleware> middlewares,
+    IFileSystem fileSystem,
+    ILivePhotoLinker livePhotoLinker,
+    IOptions<WorkerSettings> workerOptions,
+    ILogger<FileIngestionPipeline> logger) : IFileIngestionPipeline
+{
+    private readonly IngestionDelegate _pipeline = IngestionPipelineBuilder.Build([.. middlewares]);
+    private readonly WorkerSettings _settings = workerOptions.Value;
+
+    public async Task RunAsync(UserStorageConfig config, CancellationToken ct)
+    {
+        var channel = Channel.CreateBounded<IngestionItem>(
+            new BoundedChannelOptions(_settings.MaxConcurrentFiles * 2)
+            {
+                SingleWriter = true,
+                FullMode = BoundedChannelFullMode.Wait,
+            });
+
+        var producer = ProduceAsync(config, channel.Writer, ct);
+        var consumers = Enumerable
+            .Range(0, _settings.MaxConcurrentFiles)
+            .Select(_ => ConsumeAsync(config, channel.Reader, ct))
+            .ToArray();
+
+        await producer;
+        await Task.WhenAll(consumers);
+    }
+
+    private async Task ProduceAsync(
+        UserStorageConfig config,
+        ChannelWriter<IngestionItem> writer,
+        CancellationToken ct)
+    {
+        try
+        {
+            var filesByDirectory = fileSystem.Directory
+                .EnumerateFiles(config.RootPath, "*", SearchOption.AllDirectories)
+                .GroupBy(path => fileSystem.Path.GetDirectoryName(path) ?? string.Empty);
+
+            foreach (var directoryGroup in filesByDirectory)
+                await EnqueueDirectoryItemsAsync([.. directoryGroup], config.RootPath, writer, ct);
+        }
+        finally
+        {
+            writer.Complete();
+        }
+    }
+
+    private async Task EnqueueDirectoryItemsAsync(
+        IList<string> filesInDirectory,
+        string rootPath,
+        ChannelWriter<IngestionItem> writer,
+        CancellationToken ct)
+    {
+        var linkResult = livePhotoLinker.Link([.. filesInDirectory], rootPath);
+
+        foreach (var item in linkResult.Items)
+            await writer.WriteAsync(item, ct);
+
+        foreach (var filePath in filesInDirectory)
+        {
+            if (linkResult.ClaimedPaths.Contains(filePath))
+                continue;
+
+            var mediaType = MediaTypeDetector.Detect(filePath);
+            if (mediaType is null)
+            {
+                Log.UnsupportedFile(logger, filePath);
+                continue;
+            }
+
+            var relativePath = fileSystem.Path.GetRelativePath(rootPath, filePath);
+            await writer.WriteAsync(new SingleFileItem(filePath, relativePath, mediaType.Value), ct);
+        }
+    }
+
+    private async Task ConsumeAsync(
+        UserStorageConfig config,
+        ChannelReader<IngestionItem> reader,
+        CancellationToken ct)
+    {
+        await foreach (var item in reader.ReadAllAsync(ct))
+        {
+            try
+            {
+                var context = new IngestionContext { Item = item, Config = config };
+                await _pipeline(context, ct);
+            }
+            catch (PipelineConfigurationException ex)
+            {
+                Log.PipelineMisconfigured(logger, ex);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.ItemFailed(logger, item.AbsolutePath, ex);
+            }
+        }
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Warning, Message = "Skipping unsupported file type: {Path}.")]
+        public static partial void UnsupportedFile(ILogger logger, string path);
+
+        [LoggerMessage(Level = LogLevel.Critical, Message = "Ingestion pipeline is misconfigured and cannot continue.")]
+        public static partial void PipelineMisconfigured(ILogger logger, Exception ex);
+
+        [LoggerMessage(Level = LogLevel.Error, Message = "Failed to ingest {Path}.")]
+        public static partial void ItemFailed(ILogger logger, string path, Exception ex);
+    }
+}

--- a/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
+++ b/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
@@ -38,8 +38,7 @@ internal sealed partial class FileIngestionPipeline(
             .Select(_ => ConsumeAsync(config, channel.Reader, ct))
             .ToArray();
 
-        await producer;
-        await Task.WhenAll(consumers);
+        await Task.WhenAll([producer, .. consumers]);
     }
 
     private async Task ProduceAsync(
@@ -58,7 +57,7 @@ internal sealed partial class FileIngestionPipeline(
         }
         finally
         {
-            writer.Complete();
+            writer.TryComplete();
         }
     }
 
@@ -68,7 +67,7 @@ internal sealed partial class FileIngestionPipeline(
         ChannelWriter<IngestionItem> writer,
         CancellationToken ct)
     {
-        var linkResult = livePhotoLinker.Link([.. filesInDirectory], rootPath);
+        var linkResult = livePhotoLinker.Link(filesInDirectory, rootPath);
 
         foreach (var item in linkResult.Items)
             await writer.WriteAsync(item, ct);

--- a/src/Anichron.Worker/Crawling/Worker.cs
+++ b/src/Anichron.Worker/Crawling/Worker.cs
@@ -5,9 +5,10 @@ using Microsoft.Extensions.Options;
 
 namespace Anichron.Worker.Crawling;
 
-public sealed partial class Worker(
+internal sealed partial class Worker(
     IServiceScopeFactory scopeFactory,
     WorkerState workerState,
+    IFileIngestionPipeline ingestionPipeline,
     IOptions<WorkerSettings> options,
     ILogger<Worker> logger) : BackgroundService
 {
@@ -15,8 +16,8 @@ public sealed partial class Worker(
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var mode = workerState.ResolvedUserId is { } uid
-            ? $"dedicated (userId={uid})"
+        var mode = workerState.ResolvedUserId is { } userId
+            ? $"dedicated (userId={userId})"
             : "all-user";
         Log.Starting(logger, mode);
 
@@ -27,24 +28,23 @@ public sealed partial class Worker(
         }
     }
 
-    private async Task CrawlAllAsync(CancellationToken ct)
+    internal async Task CrawlAllAsync(CancellationToken ct)
     {
         using var scope = scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<IUserStorageConfigRepository>();
+        var repository = scope.ServiceProvider.GetRequiredService<IUserStorageConfigRepository>();
 
         var configs = workerState.ResolvedUserId is { } userId
-            ? await repo.GetActiveByUserIdAsync(userId, ct)
-            : await repo.GetAllActiveAsync(ct);
+            ? await repository.GetActiveByUserIdAsync(userId, ct)
+            : await repository.GetAllActiveAsync(ct);
 
         foreach (var config in configs)
             await CrawlAsync(config, ct);
     }
 
-    private Task CrawlAsync(UserStorageConfig config, CancellationToken ct)
+    private async Task CrawlAsync(UserStorageConfig config, CancellationToken ct)
     {
-        ct.ThrowIfCancellationRequested();
         Log.CrawlingPath(logger, config.RootPath, config.UserId);
-        return Task.CompletedTask;
+        await ingestionPipeline.RunAsync(config, ct);
     }
 
     private static partial class Log

--- a/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
+++ b/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
@@ -1,4 +1,7 @@
 using Anichron.Infrastructure.Configuration;
+using Anichron.Worker.Crawling;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Pipeline;
 using System.IO.Abstractions;
 
 namespace Anichron.Worker.Infrastructure;
@@ -17,9 +20,19 @@ public static class HostApplicationBuilderExtensions
                 new IniEntry("Worker", "CrawlIntervalHours", () => "4"),
                 new IniEntry("Worker", "MaxConcurrentFiles", () => "4"),
                 new IniEntry("Worker", "TokenCleanupIntervalHours", () => "24"),
+                new IniEntry("Worker", "ProxyPath", () => "/data/proxies"),
             ]);
             builder.Configuration.AddIniFile(iniPath, optional: false, reloadOnChange: false);
             builder.Configuration.AddEnvironmentVariables();
+            return builder;
+        }
+
+        public HostApplicationBuilder AddIngestionServices()
+        {
+            builder.Services.AddSingleton<IFileSystem, FileSystem>();
+            builder.Services.AddSingleton<ILivePhotoLinker, LivePhotoLinker>();
+            builder.Services.AddSingleton<IFileIngestionPipeline, FileIngestionPipeline>();
+            builder.Services.AddIngestionSteps();
             return builder;
         }
     }

--- a/src/Anichron.Worker/Ingestion/ExifData.cs
+++ b/src/Anichron.Worker/Ingestion/ExifData.cs
@@ -1,0 +1,15 @@
+using NodaTime;
+
+namespace Anichron.Worker.Ingestion;
+
+internal sealed record ExifData(
+    int Width,
+    int Height,
+    int OrientationDegrees,
+    LocalDateTime? DateCaptured,
+    float? Latitude,
+    float? Longitude,
+    string? CameraMake,
+    string? CameraModel,
+    string? LensModel,
+    float? DurationSeconds);

--- a/src/Anichron.Worker/Ingestion/IngestionItem.cs
+++ b/src/Anichron.Worker/Ingestion/IngestionItem.cs
@@ -1,0 +1,16 @@
+using Anichron.Core.Domain;
+
+namespace Anichron.Worker.Ingestion;
+
+internal abstract record IngestionItem(string AbsolutePath, string RelativePath);
+
+internal sealed record SingleFileItem(
+    string AbsolutePath,
+    string RelativePath,
+    MediaType MediaType) : IngestionItem(AbsolutePath, RelativePath);
+
+internal sealed record LivePhotoPairItem(
+    string HeicAbsolutePath,
+    string HeicRelativePath,
+    string MovAbsolutePath,
+    string MovRelativePath) : IngestionItem(HeicAbsolutePath, HeicRelativePath);

--- a/src/Anichron.Worker/Ingestion/IngestionItem.cs
+++ b/src/Anichron.Worker/Ingestion/IngestionItem.cs
@@ -10,7 +10,7 @@ internal sealed record SingleFileItem(
     MediaType MediaType) : IngestionItem(AbsolutePath, RelativePath);
 
 internal sealed record LivePhotoPairItem(
-    string HeicAbsolutePath,
-    string HeicRelativePath,
+    string AbsolutePath,
+    string RelativePath,
     string MovAbsolutePath,
-    string MovRelativePath) : IngestionItem(HeicAbsolutePath, HeicRelativePath);
+    string MovRelativePath) : IngestionItem(AbsolutePath, RelativePath);

--- a/src/Anichron.Worker/Ingestion/LivePhotoLinker.cs
+++ b/src/Anichron.Worker/Ingestion/LivePhotoLinker.cs
@@ -9,12 +9,12 @@ internal sealed record LivePhotoLinkResult(
 
 internal interface ILivePhotoLinker
 {
-    LivePhotoLinkResult Link(IReadOnlyList<string> filesInDirectory, string rootPath);
+    LivePhotoLinkResult Link(IEnumerable<string> filesInDirectory, string rootPath);
 }
 
 internal sealed class LivePhotoLinker(IFileSystem fileSystem) : ILivePhotoLinker
 {
-    public LivePhotoLinkResult Link(IReadOnlyList<string> filesInDirectory, string rootPath)
+    public LivePhotoLinkResult Link(IEnumerable<string> filesInDirectory, string rootPath)
     {
         var heicFiles = new List<string>();
         var movFilesByBaseName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);

--- a/src/Anichron.Worker/Ingestion/LivePhotoLinker.cs
+++ b/src/Anichron.Worker/Ingestion/LivePhotoLinker.cs
@@ -1,0 +1,59 @@
+using Anichron.Core.Domain;
+using System.IO.Abstractions;
+
+namespace Anichron.Worker.Ingestion;
+
+internal sealed record LivePhotoLinkResult(
+    IReadOnlyList<IngestionItem> Items,
+    IReadOnlySet<string> ClaimedPaths);
+
+internal interface ILivePhotoLinker
+{
+    LivePhotoLinkResult Link(IReadOnlyList<string> filesInDirectory, string rootPath);
+}
+
+internal sealed class LivePhotoLinker(IFileSystem fileSystem) : ILivePhotoLinker
+{
+    public LivePhotoLinkResult Link(IReadOnlyList<string> filesInDirectory, string rootPath)
+    {
+        var heicFiles = FindHeicFiles(filesInDirectory);
+        var movFilesByBaseName = IndexMovFilesByBaseName(filesInDirectory);
+
+        var items = new List<IngestionItem>(heicFiles.Count);
+        var claimedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var heicPath in heicFiles)
+        {
+            claimedPaths.Add(heicPath);
+            var baseName = fileSystem.Path.GetFileNameWithoutExtension(heicPath);
+            var heicRelativePath = fileSystem.Path.GetRelativePath(rootPath, heicPath);
+
+            if (movFilesByBaseName.TryGetValue(baseName, out var movPath))
+            {
+                var movRelativePath = fileSystem.Path.GetRelativePath(rootPath, movPath);
+                items.Add(new LivePhotoPairItem(heicPath, heicRelativePath, movPath, movRelativePath));
+                claimedPaths.Add(movPath);
+            }
+            else
+            {
+                items.Add(new SingleFileItem(heicPath, heicRelativePath, MediaType.Image));
+            }
+        }
+
+        return new LivePhotoLinkResult(items, claimedPaths);
+    }
+
+    private List<string> FindHeicFiles(IReadOnlyList<string> files)
+        => files
+            .Where(path => fileSystem.Path.GetExtension(path)
+                .Equals(MediaFileExtensions.Heic, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+    private Dictionary<string, string> IndexMovFilesByBaseName(IReadOnlyList<string> files)
+        => files
+            .Where(path => fileSystem.Path.GetExtension(path)
+                .Equals(MediaFileExtensions.Mov, StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(
+                path => fileSystem.Path.GetFileNameWithoutExtension(path),
+                StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Anichron.Worker/Ingestion/LivePhotoLinker.cs
+++ b/src/Anichron.Worker/Ingestion/LivePhotoLinker.cs
@@ -16,8 +16,17 @@ internal sealed class LivePhotoLinker(IFileSystem fileSystem) : ILivePhotoLinker
 {
     public LivePhotoLinkResult Link(IReadOnlyList<string> filesInDirectory, string rootPath)
     {
-        var heicFiles = FindHeicFiles(filesInDirectory);
-        var movFilesByBaseName = IndexMovFilesByBaseName(filesInDirectory);
+        var heicFiles = new List<string>();
+        var movFilesByBaseName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in filesInDirectory)
+        {
+            var ext = fileSystem.Path.GetExtension(path);
+            if (ext.Equals(MediaFileExtensions.Heic, StringComparison.OrdinalIgnoreCase))
+                heicFiles.Add(path);
+            else if (ext.Equals(MediaFileExtensions.Mov, StringComparison.OrdinalIgnoreCase))
+                movFilesByBaseName[fileSystem.Path.GetFileNameWithoutExtension(path)] = path;
+        }
 
         var items = new List<IngestionItem>(heicFiles.Count);
         var claimedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -42,18 +51,4 @@ internal sealed class LivePhotoLinker(IFileSystem fileSystem) : ILivePhotoLinker
 
         return new LivePhotoLinkResult(items, claimedPaths);
     }
-
-    private List<string> FindHeicFiles(IReadOnlyList<string> files)
-        => files
-            .Where(path => fileSystem.Path.GetExtension(path)
-                .Equals(MediaFileExtensions.Heic, StringComparison.OrdinalIgnoreCase))
-            .ToList();
-
-    private Dictionary<string, string> IndexMovFilesByBaseName(IReadOnlyList<string> files)
-        => files
-            .Where(path => fileSystem.Path.GetExtension(path)
-                .Equals(MediaFileExtensions.Mov, StringComparison.OrdinalIgnoreCase))
-            .ToDictionary(
-                path => fileSystem.Path.GetFileNameWithoutExtension(path),
-                StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Anichron.Worker/Ingestion/MediaFileExtensions.cs
+++ b/src/Anichron.Worker/Ingestion/MediaFileExtensions.cs
@@ -1,0 +1,7 @@
+namespace Anichron.Worker.Ingestion;
+
+internal static class MediaFileExtensions
+{
+    public const string Heic = ".heic";
+    public const string Mov = ".mov";
+}

--- a/src/Anichron.Worker/Ingestion/MediaTypeDetector.cs
+++ b/src/Anichron.Worker/Ingestion/MediaTypeDetector.cs
@@ -1,0 +1,33 @@
+using Anichron.Core.Domain;
+
+namespace Anichron.Worker.Ingestion;
+
+internal static class MediaTypeDetector
+{
+    private static readonly Dictionary<string, MediaType> ExtensionMap =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            [".jpg"] = MediaType.Image,
+            [".jpeg"] = MediaType.Image,
+            [".png"] = MediaType.Image,
+            [".heic"] = MediaType.Image,
+            [".heif"] = MediaType.Image,
+            [".gif"] = MediaType.Image,
+            [".webp"] = MediaType.Image,
+            [".tiff"] = MediaType.Image,
+            [".tif"] = MediaType.Image,
+            [".bmp"] = MediaType.Image,
+            [".mov"] = MediaType.Video,
+            [".mp4"] = MediaType.Video,
+            [".m4v"] = MediaType.Video,
+            [".avi"] = MediaType.Video,
+            [".mkv"] = MediaType.Video,
+            [".wmv"] = MediaType.Video,
+        };
+
+    public static MediaType? Detect(string filePath)
+    {
+        var extension = Path.GetExtension(filePath);
+        return ExtensionMap.TryGetValue(extension, out var type) ? type : null;
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Middlewares/LoggingMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/LoggingMiddleware.cs
@@ -1,4 +1,5 @@
 using Anichron.Worker.Ingestion.Pipeline;
+using System.Diagnostics;
 
 namespace Anichron.Worker.Ingestion.Middlewares;
 
@@ -6,7 +7,7 @@ internal sealed partial class LoggingMiddleware(ILogger<LoggingMiddleware> logge
 {
     public bool CanInvoke(IngestionContext context) => true;
 
-    public IngestionStepError OnCannotInvoke(IngestionContext context) => new(string.Empty);
+    public IngestionStepError OnCannotInvoke(IngestionContext context) => throw new UnreachableException();
 
     public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
     {

--- a/src/Anichron.Worker/Ingestion/Middlewares/LoggingMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/LoggingMiddleware.cs
@@ -1,0 +1,26 @@
+using Anichron.Worker.Ingestion.Pipeline;
+
+namespace Anichron.Worker.Ingestion.Middlewares;
+
+internal sealed partial class LoggingMiddleware(ILogger<LoggingMiddleware> logger) : IIngestionMiddleware
+{
+    public bool CanInvoke(IngestionContext context) => true;
+
+    public IngestionStepError OnCannotInvoke(IngestionContext context) => new(string.Empty);
+
+    public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
+    {
+        Log.ItemStarted(logger, context.Item.AbsolutePath);
+        await next(context, ct);
+        Log.ItemCompleted(logger, context.Item.AbsolutePath);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Ingesting {Path}.")]
+        public static partial void ItemStarted(ILogger logger, string path);
+
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Completed {Path}.")]
+        public static partial void ItemCompleted(ILogger logger, string path);
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Pipeline/IIngestionMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IIngestionMiddleware.cs
@@ -1,0 +1,12 @@
+namespace Anichron.Worker.Ingestion.Pipeline;
+
+internal delegate Task IngestionDelegate(IngestionContext context, CancellationToken ct);
+
+internal interface IIngestionMiddleware
+{
+    bool CanInvoke(IngestionContext context);
+    IngestionStepError OnCannotInvoke(IngestionContext context);
+    Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct);
+}
+
+internal sealed record IngestionStepError(string Message);

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionContext.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionContext.cs
@@ -1,0 +1,23 @@
+using Anichron.Core.Domain;
+
+namespace Anichron.Worker.Ingestion.Pipeline;
+
+internal interface IWithHash
+{ string? ContentHash { get; set; } }
+internal interface IWithExif
+{ ExifData? Exif { get; set; } }
+internal interface IWithAsset
+{ MediaAsset? Asset { get; set; } }
+internal interface IWithProxies
+{ List<ProxyFile> ProxyFiles { get; } }
+
+internal sealed class IngestionContext : IWithHash, IWithExif, IWithAsset, IWithProxies
+{
+    public required IngestionItem Item { get; init; }
+    public required UserStorageConfig Config { get; init; }
+
+    public string? ContentHash { get; set; }
+    public ExifData? Exif { get; set; }
+    public MediaAsset? Asset { get; set; }
+    public List<ProxyFile> ProxyFiles { get; } = [];
+}

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
@@ -1,0 +1,46 @@
+using Anichron.Worker.Ingestion.Middlewares;
+
+namespace Anichron.Worker.Ingestion.Pipeline;
+
+internal static class IngestionServiceCollectionExtensions
+{
+    public static IServiceCollection AddIngestionSteps(this IServiceCollection services)
+    {
+        services.AddSingleton<IIngestionMiddleware, LoggingMiddleware>();
+        return services;
+    }
+}
+
+internal static class IngestionPipelineBuilder
+{
+    // Composes middlewares into a single IngestionDelegate.
+    // Each step is wrapped with a CanInvoke guard — middleware authors never write this themselves.
+    internal static IngestionDelegate Build(IReadOnlyList<IIngestionMiddleware> middlewares)
+    {
+        // Terminal step: the last middleware's `next` calls this, completing the chain.
+        IngestionDelegate pipeline = static (_, _) => Task.CompletedTask;
+
+        // Build right-to-left so the composed chain runs left-to-right:
+        // wrapping middleware[n-1] first means middleware[0] is the outermost caller.
+        foreach (var middleware in middlewares.Reverse())
+        {
+            // Capture loop variables into locals; lambdas close over the local, not
+            // the loop variable, so each iteration gets its own independent copy.
+            var next = pipeline;
+            var current = middleware;
+            pipeline = async (context, ct) =>
+            {
+                if (!current.CanInvoke(context))
+                {
+                    var error = current.OnCannotInvoke(context);
+                    throw new PipelineConfigurationException(
+                        $"{current.GetType().Name} cannot invoke: {error.Message}");
+                }
+
+                await current.InvokeAsync(context, next, ct);
+            };
+        }
+
+        return pipeline;
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
@@ -2,11 +2,8 @@ namespace Anichron.Worker.Ingestion.Pipeline;
 
 internal static class IngestionPipelineBuilder
 {
-    // Composes middlewares into a single IngestionDelegate.
-    // Each step is wrapped with a CanInvoke guard — middleware authors never write this themselves.
     internal static IngestionDelegate Build(IReadOnlyList<IIngestionMiddleware> middlewares)
     {
-        // Terminal step: the last middleware's `next` calls this, completing the chain.
         IngestionDelegate pipeline = static (_, _) => Task.CompletedTask;
 
         // Build right-to-left so the composed chain runs left-to-right:

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
@@ -1,15 +1,4 @@
-using Anichron.Worker.Ingestion.Middlewares;
-
 namespace Anichron.Worker.Ingestion.Pipeline;
-
-internal static class IngestionServiceCollectionExtensions
-{
-    public static IServiceCollection AddIngestionSteps(this IServiceCollection services)
-    {
-        services.AddSingleton<IIngestionMiddleware, LoggingMiddleware>();
-        return services;
-    }
-}
 
 internal static class IngestionPipelineBuilder
 {

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
@@ -1,0 +1,12 @@
+using Anichron.Worker.Ingestion.Middlewares;
+
+namespace Anichron.Worker.Ingestion.Pipeline;
+
+internal static class IngestionServiceCollectionExtensions
+{
+    public static IServiceCollection AddIngestionSteps(this IServiceCollection services)
+    {
+        services.AddSingleton<IIngestionMiddleware, LoggingMiddleware>();
+        return services;
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Pipeline/PipelineConfigurationException.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/PipelineConfigurationException.cs
@@ -1,0 +1,10 @@
+namespace Anichron.Worker.Ingestion.Pipeline;
+
+public sealed class PipelineConfigurationException : Exception
+{
+    public PipelineConfigurationException() { }
+
+    public PipelineConfigurationException(string message) : base(message) { }
+
+    public PipelineConfigurationException(string? message, Exception? innerException) : base(message, innerException) { }
+}

--- a/src/Anichron.Worker/Maintenance/TokenCleanupService.cs
+++ b/src/Anichron.Worker/Maintenance/TokenCleanupService.cs
@@ -33,9 +33,9 @@ public sealed partial class TokenCleanupService(
     internal async Task RunCleanupAsync(CancellationToken ct)
     {
         using var scope = scopeFactory.CreateScope();
-        var repo = scope.ServiceProvider.GetRequiredService<IRefreshTokenRepository>();
+        var repository = scope.ServiceProvider.GetRequiredService<IRefreshTokenRepository>();
         var now = clock.GetCurrentInstant();
-        var deleted = await repo.DeleteExpiredAsync(now, ct);
+        var deleted = await repository.DeleteExpiredAsync(now, ct);
         Log.TokensDeleted(logger, deleted);
     }
 

--- a/src/Anichron.Worker/Program.cs
+++ b/src/Anichron.Worker/Program.cs
@@ -12,6 +12,7 @@ using System.IO.Abstractions;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.AddAppConfiguration();
+builder.AddIngestionServices();
 
 builder.Services.Configure<WorkerSettings>(builder.Configuration.GetSection("Worker"));
 builder.Services.AddSingleton<IClock>(SystemClock.Instance);

--- a/src/Anichron.Worker/Settings/WorkerSettings.cs
+++ b/src/Anichron.Worker/Settings/WorkerSettings.cs
@@ -11,4 +11,6 @@ public sealed record WorkerSettings
     public int MaxConcurrentFiles { get; init; } = 4;
 
     public double TokenCleanupIntervalHours { get; init; } = 24;
+
+    public string ProxyPath { get; init; } = "/data/proxies";
 }


### PR DESCRIPTION
## Summary

- Adds the bounded-concurrency `Channel<T>` producer/consumer pipeline (`FileIngestionPipeline`) that crawls a NAS root and dispatches `IngestionItem`s to N concurrent workers
- Introduces the middleware chain (`IngestionPipelineBuilder`, `IIngestionMiddleware`, `IngestionDelegate`) with a `CanInvoke` guard that throws `PipelineConfigurationException` for misconfigured pipelines
- Extracts `ILivePhotoLinker` / `LivePhotoLinker` to pair HEIC + MOV siblings into `LivePhotoPairItem`s (SRP; fully unit-tested in isolation)
- Converts `MediaTypeDetector` to a `static class` — pure lookup with no instance state, removing an unnecessary interface and DI registration
- Adds `LoggingMiddleware` as Batch 0's only pipeline step; logs start/completion/failure per item at Debug level
- Organises code under `Ingestion/Pipeline/` (framework abstractions), `Ingestion/Middlewares/`, and `Ingestion/` (domain utilities)
- Registers everything via `AddIngestionSteps()` and extension methods on `HostApplicationBuilder`

## Test plan

- [ ] `dotnet build src/` — 0 warnings, 0 errors
- [ ] `dotnet test src/` — all 454 tests pass
  - `FileIngestionPipelineTests` — live photo pairing, unsupported file skipping, relative paths, cross-directory isolation, `PipelineConfigurationException` propagation
  - `LivePhotoLinkerTests` — pairing, unmatched HEIC/MOV, case-insensitive matching, empty input
  - `MediaTypeDetectorTests` — all image/video extensions, case insensitivity, unknown extensions
  - `IngestionPipelineBuilderTests` — ordering, empty pipeline, `CanInvoke` guard behaviour
  - `LoggingMiddlewareTests` — next delegation, exception propagation, log output assertions
- [ ] `dotnet format src/ --verify-no-changes` — no style issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)