### PR TITLE
feat(worker): Content hashing, EXIF extraction, and idempotency pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,16 +133,7 @@ Processing uses a bounded-concurrency `Channel<T>` pipeline. The crawler produce
 - Observability: structured JSON logging in production; `GET /api/v1/healthz` health endpoint; OpenTelemetry instrumented but no exporter configured by default (`OTEL_EXPORTER_OTLP_ENDPOINT` to enable).
 - License: AGPL-3.0.
 
-## Development Roadmap
+## GitHub References
 
-The project is in early stages. Epic 1 (Foundation & Infrastructure) is largely complete. Remaining epics in order:
-
-1. **Epic 2**: User management & JWT authentication
-2. **Epic 3**: Full media ingestion pipeline (EXIF, hashing, proxies, bursts)
-3. **Epic 4**: NAS reconciliation (soft-delete, move detection, deduplication)
-4. **Epic 5**: API endpoints (flashback queries, file serving, interactions)
-5. **Epic 6**: Flashback UI (story player, Live Photo, blurhash, pre-fetching)
-6. **Epic 7**: Recaps & calendar views
-7. **Epic 8**: Email notifications with deep links
-
-Additional context is in `../Anichron-Documentation/` (adjacent repo): `requirements.txt`, `solution-overview.txt`, `roadmap.md`, `database/database-decisions.txt`, and an ERD in `database/erd-mermaid.txt`.
+- **Issues** (bug reports, feature requests, epic tracking): https://github.com/bitbiter-dev/anichron/issues
+- **Wiki** (architecture decisions, ADRs, engineering notes): https://github.com/bitbiter-dev/anichron/wiki

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -240,35 +240,26 @@ dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, meth
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
 dotnet_naming_symbols.non_field_members.required_modifiers = 
 
-# Enforce _camelCase for private instance fields
-dotnet_naming_rule.private_instance_fields_rule.severity = warning
-dotnet_naming_rule.private_instance_fields_rule.symbols = private_instance_fields
-dotnet_naming_rule.private_instance_fields_rule.style = private_instance_prefix_style
+# Enforce camelCase for all private fields (instance and static)
+dotnet_naming_rule.private_fields_rule.severity = warning
+dotnet_naming_rule.private_fields_rule.symbols = private_fields
+dotnet_naming_rule.private_fields_rule.style = camel_case
 
-dotnet_naming_symbols.private_instance_fields.applicable_kinds = field
-dotnet_naming_symbols.private_instance_fields.applicable_accessibilities = private
-dotnet_naming_symbols.private_instance_fields.required_modifiers = instance
-
-dotnet_naming_style.private_instance_prefix_style.capitalization = camel_case
-dotnet_naming_style.private_instance_prefix_style.required_prefix = _
-
-# Enforce PascalCase for private static fields
-dotnet_naming_rule.private_static_fields_rule.severity = warning
-dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields
-dotnet_naming_rule.private_static_fields_rule.style = pascal_case
-
-dotnet_naming_symbols.private_static_fields.applicable_kinds = field
-dotnet_naming_symbols.private_static_fields.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_fields.required_modifiers = static
-
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_symbols.private_fields.required_modifiers =
 
 # Naming styles
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.camel_case.required_prefix =
+dotnet_naming_style.camel_case.required_suffix =
+dotnet_naming_style.camel_case.word_separator =
+dotnet_naming_style.camel_case.capitalization = camel_case
 
 dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 

--- a/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
+++ b/src/Anichron.API/Infrastructure/MustChangePasswordMiddleware.cs
@@ -4,7 +4,7 @@ namespace Anichron.API.Infrastructure;
 
 internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
 {
-    private static readonly (string Method, PathString Path)[] ExemptRoutes =
+    private static readonly (string Method, PathString Path)[] exemptRoutes =
     [
         (HttpMethods.Get,  new(ApiPaths.Users.MePath)),
         (HttpMethods.Post, new(ApiPaths.Users.ChangePasswordPath)),
@@ -26,5 +26,5 @@ internal sealed class MustChangePasswordMiddleware(RequestDelegate next)
     }
 
     private static bool IsExemptRequest(HttpRequest request)
-        => ExemptRoutes.Any(e => e.Method == request.Method && e.Path == request.Path);
+        => exemptRoutes.Any(e => e.Method == request.Method && e.Path == request.Path);
 }

--- a/src/Anichron.API/Security/JwtFactory.cs
+++ b/src/Anichron.API/Security/JwtFactory.cs
@@ -15,20 +15,20 @@ public interface IJwtFactory
 
 public sealed class JwtFactory : IJwtFactory
 {
-    private readonly JwtSettings _settings;
-    private readonly IClock _clock;
-    private readonly IGuidFactory _guidFactory;
-    private readonly SigningCredentials _credentials;
-    private static readonly JwtSecurityTokenHandler TokenHandler = new();
+    private readonly JwtSettings settings;
+    private readonly IClock clock;
+    private readonly IGuidFactory guidFactory;
+    private readonly SigningCredentials credentials;
+    private static readonly JwtSecurityTokenHandler tokenHandler = new();
 
     public JwtFactory(IOptions<JwtSettings> options, IClock clock, IGuidFactory guidFactory)
     {
-        _settings = options.Value;
-        _clock = clock;
-        _guidFactory = guidFactory;
+        settings = options.Value;
+        this.clock = clock;
+        this.guidFactory = guidFactory;
 
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_settings.Secret));
-        _credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(settings.Secret));
+        credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
     }
 
     public string Create(User user)
@@ -37,7 +37,7 @@ public sealed class JwtFactory : IJwtFactory
         {
             new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
             new(JwtRegisteredClaimNames.UniqueName, user.Username),
-            new(JwtRegisteredClaimNames.Jti, _guidFactory.NewGuid().ToString()),
+            new(JwtRegisteredClaimNames.Jti, guidFactory.NewGuid().ToString()),
         };
 
         if (user.MustChangePassword)
@@ -47,12 +47,12 @@ public sealed class JwtFactory : IJwtFactory
             claims.Add(new Claim(AppClaimTypes.IsAdmin, "true"));
 
         var token = new JwtSecurityToken(
-            issuer: _settings.Issuer,
-            audience: _settings.Audience,
+            issuer: settings.Issuer,
+            audience: settings.Audience,
             claims: claims,
-            expires: _clock.GetCurrentInstant().ToDateTimeUtc().AddMinutes(_settings.AccessTokenMinutes),
-            signingCredentials: _credentials);
+            expires: clock.GetCurrentInstant().ToDateTimeUtc().AddMinutes(settings.AccessTokenMinutes),
+            signingCredentials: credentials);
 
-        return TokenHandler.WriteToken(token);
+        return tokenHandler.WriteToken(token);
     }
 }

--- a/src/Anichron.API/Services/AuthService.cs
+++ b/src/Anichron.API/Services/AuthService.cs
@@ -62,7 +62,7 @@ public sealed class AuthService(
     ILockoutService lockout)
     : IAuthService
 {
-    private readonly string _dummyPasswordHash = passwordHasher.Hash(guidFactory.NewGuid().ToString());
+    private readonly string dummyPasswordHash = passwordHasher.Hash(guidFactory.NewGuid().ToString());
 
     public async Task<AuthResult<AuthTokens>> RegisterAsync(string username, string email, string password, string inviteToken, CancellationToken ct)
     {
@@ -131,7 +131,7 @@ public sealed class AuthService(
         var user = await users.FindByCredentialAsync(normalized, ct);
 
         // Prevent timing attack: Use dummy hash for non-existing accounts
-        var passwordValid = passwordHasher.Verify(password, user?.PasswordHash ?? _dummyPasswordHash);
+        var passwordValid = passwordHasher.Verify(password, user?.PasswordHash ?? dummyPasswordHash);
 
         var now = clock.GetCurrentInstant();
 

--- a/src/Anichron.API/Services/RegistrationValidator.cs
+++ b/src/Anichron.API/Services/RegistrationValidator.cs
@@ -16,13 +16,13 @@ public sealed class RegistrationValidator(
     IOptions<UsernamePolicy> usernamePolicyOptions,
     IPwnedPasswordClient pwnedClient) : IRegistrationValidator
 {
-    private readonly PasswordPolicy _passwordPolicy = passwordPolicyOptions.Value;
-    private readonly UsernamePolicy _usernamePolicy = usernamePolicyOptions.Value;
+    private readonly PasswordPolicy passwordPolicy = passwordPolicyOptions.Value;
+    private readonly UsernamePolicy usernamePolicy = usernamePolicyOptions.Value;
 
     public AuthError? ValidateIdentity(string username, string email)
     {
-        if (username.Length < _usernamePolicy.MinLength
-            || username.Length > _usernamePolicy.MaxLength
+        if (username.Length < usernamePolicy.MinLength
+            || username.Length > usernamePolicy.MaxLength
             || !UsernamePolicy.AllowedCharacters().IsMatch(username))
         {
             return AuthError.InvalidUsername;
@@ -44,15 +44,15 @@ public sealed class RegistrationValidator(
 
     private async Task<AuthError?> ValidatePasswordRulesAsync(string password, CancellationToken ct)
     {
-        if (password.Length < _passwordPolicy.MinLength)
+        if (password.Length < passwordPolicy.MinLength)
             return AuthError.PasswordTooShort;
 
-        if (password.Length > _passwordPolicy.MaxLength)
+        if (password.Length > passwordPolicy.MaxLength)
             return AuthError.PasswordTooLong;
 
         // IDE0046 suppressed: collapsing an async condition into a ternary reduces readability
 #pragma warning disable IDE0046
-        if (_passwordPolicy.CheckPwnedPasswords && await pwnedClient.IsPwnedAsync(password, ct))
+        if (passwordPolicy.CheckPwnedPasswords && await pwnedClient.IsPwnedAsync(password, ct))
 #pragma warning restore IDE0046
             return AuthError.PasswordPwned;
 

--- a/src/Anichron.API/Services/TokenService.cs
+++ b/src/Anichron.API/Services/TokenService.cs
@@ -24,7 +24,7 @@ public sealed class TokenService(
     IOptions<JwtSettings> options,
     IJwtFactory jwtFactory) : ITokenService
 {
-    private readonly JwtSettings _settings = options.Value;
+    private readonly JwtSettings settings = options.Value;
 
     public async Task<AuthTokens> IssueAsync(User user, CancellationToken ct)
     {
@@ -37,7 +37,7 @@ public sealed class TokenService(
             UserId = user.Id,
             TokenHash = HashToken(rawToken),
             CreatedAt = now,
-            ExpiresAt = now.Plus(Duration.FromDays(_settings.RefreshTokenDays)),
+            ExpiresAt = now.Plus(Duration.FromDays(settings.RefreshTokenDays)),
         });
 
         await unitOfWork.SaveChangesAsync(ct);

--- a/src/Anichron.Core/Data/Repository/MediaAssetRepository.cs
+++ b/src/Anichron.Core/Data/Repository/MediaAssetRepository.cs
@@ -1,0 +1,19 @@
+using Anichron.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Anichron.Core.Data.Repository;
+
+public interface IMediaAssetRepository
+{
+    Task<MediaAsset?> FindByHashAsync(string contentHash, CancellationToken ct);
+    void Add(MediaAsset asset);
+}
+
+public sealed class EfMediaAssetRepository(AnichronDbContext db) : IMediaAssetRepository
+{
+    public Task<MediaAsset?> FindByHashAsync(string contentHash, CancellationToken ct)
+        => db.MediaAssets.FirstOrDefaultAsync(a => a.ContentHash == contentHash, ct);
+
+    public void Add(MediaAsset asset)
+        => db.MediaAssets.Add(asset);
+}

--- a/src/Anichron.Core/Data/Repository/MediaAssetRepository.cs
+++ b/src/Anichron.Core/Data/Repository/MediaAssetRepository.cs
@@ -12,7 +12,7 @@ public interface IMediaAssetRepository
 public sealed class EfMediaAssetRepository(AnichronDbContext db) : IMediaAssetRepository
 {
     public Task<MediaAsset?> FindByHashAsync(string contentHash, CancellationToken ct)
-        => db.MediaAssets.FirstOrDefaultAsync(a => a.ContentHash == contentHash, ct);
+        => db.MediaAssets.SingleOrDefaultAsync(a => a.ContentHash == contentHash, ct);
 
     public void Add(MediaAsset asset)
         => db.MediaAssets.Add(asset);

--- a/src/Anichron.Core/Domain/Metadata.cs
+++ b/src/Anichron.Core/Domain/Metadata.cs
@@ -12,8 +12,8 @@ public class Metadata
     public int OrientationDegrees { get; set; }
 
     // Location
-    public float? Latitude { get; set; }
-    public float? Longitude { get; set; }
+    public double? Latitude { get; set; }
+    public double? Longitude { get; set; }
 
     // Hardware Specs
     public string? CameraMake { get; set; }
@@ -21,5 +21,5 @@ public class Metadata
     public string? LensModel { get; set; }
 
     // Video/File Specifics
-    public float? DurationSeconds { get; set; }
+    public int? DurationInSeconds { get; set; }
 }

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.Designer.cs
@@ -207,20 +207,20 @@ namespace Anichron.Core.Migrations
                     b.Property<string>("CameraModel")
                         .HasColumnType("text");
 
-                    b.Property<float?>("DurationSeconds")
-                        .HasColumnType("real");
+                    b.Property<int?>("DurationInSeconds")
+                        .HasColumnType("integer");
 
                     b.Property<int>("Height")
                         .HasColumnType("integer");
 
-                    b.Property<float?>("Latitude")
-                        .HasColumnType("real");
+                    b.Property<double?>("Latitude")
+                        .HasColumnType("double precision");
 
                     b.Property<string>("LensModel")
                         .HasColumnType("text");
 
-                    b.Property<float?>("Longitude")
-                        .HasColumnType("real");
+                    b.Property<double?>("Longitude")
+                        .HasColumnType("double precision");
 
                     b.Property<int>("OrientationDegrees")
                         .HasColumnType("integer");

--- a/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
+++ b/src/Anichron.Core/Migrations/20260511154104_InitialSchema.cs
@@ -195,12 +195,12 @@ namespace Anichron.Core.Migrations
                     Width = table.Column<int>(type: "integer", nullable: false),
                     Height = table.Column<int>(type: "integer", nullable: false),
                     OrientationDegrees = table.Column<int>(type: "integer", nullable: false),
-                    Latitude = table.Column<float>(type: "real", nullable: true),
-                    Longitude = table.Column<float>(type: "real", nullable: true),
+                    Latitude = table.Column<double>(type: "double precision", nullable: true),
+                    Longitude = table.Column<double>(type: "double precision", nullable: true),
                     CameraMake = table.Column<string>(type: "text", nullable: true),
                     CameraModel = table.Column<string>(type: "text", nullable: true),
                     LensModel = table.Column<string>(type: "text", nullable: true),
-                    DurationSeconds = table.Column<float>(type: "real", nullable: true)
+                    DurationInSeconds = table.Column<int>(type: "integer", nullable: true)
                 },
                 constraints: table =>
                 {

--- a/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
+++ b/src/Anichron.Core/Migrations/AnichronDbContextModelSnapshot.cs
@@ -204,20 +204,20 @@ namespace Anichron.Core.Migrations
                     b.Property<string>("CameraModel")
                         .HasColumnType("text");
 
-                    b.Property<float?>("DurationSeconds")
-                        .HasColumnType("real");
+                    b.Property<int?>("DurationInSeconds")
+                        .HasColumnType("integer");
 
                     b.Property<int>("Height")
                         .HasColumnType("integer");
 
-                    b.Property<float?>("Latitude")
-                        .HasColumnType("real");
+                    b.Property<double?>("Latitude")
+                        .HasColumnType("double precision");
 
                     b.Property<string>("LensModel")
                         .HasColumnType("text");
 
-                    b.Property<float?>("Longitude")
-                        .HasColumnType("real");
+                    b.Property<double?>("Longitude")
+                        .HasColumnType("double precision");
 
                     b.Property<int>("OrientationDegrees")
                         .HasColumnType("integer");

--- a/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
@@ -3,6 +3,7 @@ using Anichron.Worker.Crawling;
 using Anichron.Worker.Ingestion;
 using Anichron.Worker.Ingestion.Pipeline;
 using Anichron.Worker.Settings;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.IO.Abstractions.TestingHelpers;
@@ -22,7 +23,6 @@ public sealed class FileIngestionPipelineTests
     {
         public MockFileSystem FileSystem { get; } = new();
         public List<IngestionContext> ProcessedContexts { get; } = [];
-        public List<IIngestionMiddleware> Middlewares { get; } = [];
 
         public FileIngestionPipeline Build(int maxConcurrentFiles = 2)
         {
@@ -39,11 +39,29 @@ public sealed class FileIngestionPipelineTests
                     return Task.CompletedTask;
                 });
 
-            Middlewares.Add(capturingMiddleware);
+            return BuildWithMiddlewares([capturingMiddleware], maxConcurrentFiles);
+        }
+
+        public FileIngestionPipeline BuildWithMiddlewares(
+            IEnumerable<IIngestionMiddleware> middlewares,
+            int maxConcurrentFiles = 2)
+        {
+            var runner = new IngestionPipelineRunner(
+                middlewares,
+                Substitute.For<ILogger<IngestionPipelineRunner>>());
+
+            var serviceProvider = Substitute.For<IServiceProvider>();
+            serviceProvider.GetService(typeof(IIngestionPipelineRunner)).Returns(runner);
+
+            var scope = Substitute.For<IServiceScope>();
+            scope.ServiceProvider.Returns(serviceProvider);
+
+            var scopeFactory = Substitute.For<IServiceScopeFactory>();
+            scopeFactory.CreateScope().Returns(_ => scope);
 
             var options = Options.Create(new WorkerSettings { MaxConcurrentFiles = maxConcurrentFiles });
             return new FileIngestionPipeline(
-                Middlewares,
+                scopeFactory,
                 FileSystem,
                 new LivePhotoLinker(FileSystem),
                 options,
@@ -170,15 +188,8 @@ public sealed class FileIngestionPipelineTests
         failingMiddleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
         failingMiddleware.OnCannotInvoke(Arg.Any<IngestionContext>())
             .Returns(new IngestionStepError("required slot missing"));
-        fixture.Middlewares.Add(failingMiddleware);
 
-        var options = Options.Create(new WorkerSettings { MaxConcurrentFiles = 1 });
-        var pipeline = new FileIngestionPipeline(
-            fixture.Middlewares,
-            fixture.FileSystem,
-            new LivePhotoLinker(fixture.FileSystem),
-            options,
-            Substitute.For<ILogger<FileIngestionPipeline>>());
+        var pipeline = fixture.BuildWithMiddlewares([failingMiddleware], maxConcurrentFiles: 1);
 
         var act = async () => await pipeline.RunAsync(MakeConfig("/nas"), CancellationToken.None);
 

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ContentHashingMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ContentHashingMiddlewareTests.cs
@@ -1,0 +1,116 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Middlewares;
+using Anichron.Worker.Ingestion.Pipeline;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Middlewares;
+
+public sealed class ContentHashingMiddlewareTests
+{
+    private static IngestionContext MakeContext(string path = "/abs/photo.jpg") => new()
+    {
+        Item = new SingleFileItem(path, "photo.jpg", MediaType.Image),
+        Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+    };
+
+    // ==========================================================================
+    // CanInvoke
+    // ==========================================================================
+
+    [Fact]
+    public void CanInvoke_Always_ReturnsTrue()
+    {
+        var middleware = new ContentHashingMiddleware(new MockFileSystem());
+        middleware.CanInvoke(MakeContext()).Should().BeTrue();
+    }
+
+    // ==========================================================================
+    // InvokeAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_Always_CallsNextAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData([0x01, 0x02, 0x03]),
+        });
+        var nextCalled = false;
+        Task NextAsync(IngestionContext ctx, CancellationToken ct)
+        {
+            _ = (ctx, ct);
+            nextCalled = true;
+            return Task.CompletedTask;
+        }
+
+        await new ContentHashingMiddleware(fs).InvokeAsync(MakeContext("/abs/photo.jpg"), NextAsync, CancellationToken.None);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Always_SetsNonEmptyHashAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData([0x01, 0x02, 0x03]),
+        });
+        var context = MakeContext("/abs/photo.jpg");
+
+        await new ContentHashingMiddleware(fs).InvokeAsync(context, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        context.ContentHash.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SameContent_ProducesSameHashAsync()
+    {
+        byte[] content = [0xAA, 0xBB, 0xCC];
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/a.jpg"] = new MockFileData(content),
+            ["/abs/b.jpg"] = new MockFileData(content),
+        });
+        var contextA = new IngestionContext
+        {
+            Item = new SingleFileItem("/abs/a.jpg", "a.jpg", MediaType.Image),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        };
+        var contextB = new IngestionContext
+        {
+            Item = new SingleFileItem("/abs/b.jpg", "b.jpg", MediaType.Image),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        };
+
+        await new ContentHashingMiddleware(fs).InvokeAsync(contextA, (_, _) => Task.CompletedTask, CancellationToken.None);
+        await new ContentHashingMiddleware(fs).InvokeAsync(contextB, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        contextA.ContentHash.Should().Be(contextB.ContentHash);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_DifferentContent_ProducesDifferentHashAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/a.jpg"] = new MockFileData([0x01, 0x02]),
+            ["/abs/b.jpg"] = new MockFileData([0x03, 0x04]),
+        });
+        var contextA = new IngestionContext
+        {
+            Item = new SingleFileItem("/abs/a.jpg", "a.jpg", MediaType.Image),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        };
+        var contextB = new IngestionContext
+        {
+            Item = new SingleFileItem("/abs/b.jpg", "b.jpg", MediaType.Image),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        };
+
+        await new ContentHashingMiddleware(fs).InvokeAsync(contextA, (_, _) => Task.CompletedTask, CancellationToken.None);
+        await new ContentHashingMiddleware(fs).InvokeAsync(contextB, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        contextA.ContentHash.Should().NotBe(contextB.ContentHash);
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ExifExtractionMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ExifExtractionMiddlewareTests.cs
@@ -141,4 +141,23 @@ public sealed class ExifExtractionMiddlewareTests
         context.Exif!.Latitude.Should().BeNull();
         context.Exif!.Longitude.Should().BeNull();
     }
+
+    [Fact]
+    public async Task InvokeAsync_UnreadableFile_SetsEmptyExifAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData([0x00, 0x00, 0x00, 0x00]),
+        });
+        var context = MakeContext("/abs/photo.jpg");
+
+        await MakeMiddleware(fs).InvokeAsync(context, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        context.Exif!.Width.Should().Be(0);
+        context.Exif!.Height.Should().Be(0);
+        context.Exif!.OrientationDegrees.Should().Be(0);
+        context.Exif!.DateCaptured.Should().BeNull();
+        context.Exif!.Latitude.Should().BeNull();
+        context.Exif!.Longitude.Should().BeNull();
+    }
 }

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ExifExtractionMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ExifExtractionMiddlewareTests.cs
@@ -1,0 +1,144 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Middlewares;
+using Anichron.Worker.Ingestion.Pipeline;
+using Microsoft.Extensions.Logging;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Middlewares;
+
+public sealed class ExifExtractionMiddlewareTests
+{
+    // Minimal JPEG with EXIF IFD0: Width=100, Height=200, Orientation=6 (90°)
+    private static readonly byte[] JpegWithExif =
+    [
+        0xFF, 0xD8,                                                               // SOI
+        0xFF, 0xE1, 0x00, 0x3A,                                                  // APP1 marker + length (58)
+        0x45, 0x78, 0x69, 0x66, 0x00, 0x00,                                     // "Exif\0\0"
+        0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00,                        // TIFF LE header; IFD0 at offset 8
+        0x03, 0x00,                                                               // 3 IFD entries
+        0x00, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, // Width = 100
+        0x01, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0xC8, 0x00, 0x00, 0x00, // Height = 200
+        0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, // Orientation = 6
+        0x00, 0x00, 0x00, 0x00,                                                  // Next IFD = 0
+        0xFF, 0xD9,                                                               // EOI
+    ];
+
+    private static readonly byte[] JpegWithoutExif = [0xFF, 0xD8, 0xFF, 0xD9];
+
+    private static IngestionContext MakeContext(string path = "/abs/photo.jpg", string? contentHash = "deadbeef") => new()
+    {
+        Item = new SingleFileItem(path, "photo.jpg", MediaType.Image),
+        Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        ContentHash = contentHash,
+    };
+
+    private static ExifExtractionMiddleware MakeMiddleware(MockFileSystem fs)
+        => new(fs, Substitute.For<ILogger<ExifExtractionMiddleware>>());
+
+    // ==========================================================================
+    // CanInvoke
+    // ==========================================================================
+
+    [Fact]
+    public void CanInvoke_WhenHashSet_ReturnsTrue()
+    {
+        var middleware = MakeMiddleware(new MockFileSystem());
+        var context = MakeContext();
+        context.ContentHash = "abc123";
+        middleware.CanInvoke(context).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanInvoke_WhenHashNull_ReturnsFalse()
+    {
+        var middleware = MakeMiddleware(new MockFileSystem());
+        middleware.CanInvoke(MakeContext(contentHash: null)).Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // InvokeAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_Always_CallsNextAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData(JpegWithExif),
+        });
+        var nextCalled = false;
+        Task NextAsync(IngestionContext ctx, CancellationToken ct)
+        {
+            _ = (ctx, ct);
+            nextCalled = true;
+            return Task.CompletedTask;
+        }
+
+        await MakeMiddleware(fs).InvokeAsync(MakeContext("/abs/photo.jpg"), NextAsync, CancellationToken.None);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Always_SetsExifOnContextAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData(JpegWithExif),
+        });
+        var context = MakeContext("/abs/photo.jpg");
+
+        await MakeMiddleware(fs).InvokeAsync(context, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        context.Exif.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ValidJpegExif_ExtractsCorrectDimensionsAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData(JpegWithExif),
+        });
+        var context = MakeContext("/abs/photo.jpg");
+
+        await MakeMiddleware(fs).InvokeAsync(context, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        context.Exif!.Width.Should().Be(100);
+        context.Exif!.Height.Should().Be(200);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ExifOrientationSix_MapsToNinetyDegreesAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData(JpegWithExif),
+        });
+        var context = MakeContext("/abs/photo.jpg");
+
+        await MakeMiddleware(fs).InvokeAsync(context, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        context.Exif!.OrientationDegrees.Should().Be(90);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MissingExif_SetsSafeDefaultsAsync()
+    {
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/abs/photo.jpg"] = new MockFileData(JpegWithoutExif),
+        });
+        var context = MakeContext("/abs/photo.jpg");
+
+        await MakeMiddleware(fs).InvokeAsync(context, (_, _) => Task.CompletedTask, CancellationToken.None);
+
+        context.Exif!.Width.Should().Be(0);
+        context.Exif!.Height.Should().Be(0);
+        context.Exif!.OrientationDegrees.Should().Be(0);
+        context.Exif!.DateCaptured.Should().BeNull();
+        context.Exif!.Latitude.Should().BeNull();
+        context.Exif!.Longitude.Should().BeNull();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/IdempotencyCheckMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/IdempotencyCheckMiddlewareTests.cs
@@ -1,0 +1,100 @@
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Middlewares;
+using Anichron.Worker.Ingestion.Pipeline;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Middlewares;
+
+public sealed class IdempotencyCheckMiddlewareTests
+{
+    private sealed class TestFixture
+    {
+        public IMediaAssetRepository Repository { get; } = Substitute.For<IMediaAssetRepository>();
+
+        private readonly IServiceScopeFactory scopeFactory;
+
+        public TestFixture()
+        {
+            var serviceProvider = Substitute.For<IServiceProvider>();
+            var scope = Substitute.For<IServiceScope>();
+            scope.ServiceProvider.Returns(serviceProvider);
+
+            var factory = Substitute.For<IServiceScopeFactory>();
+            factory.CreateScope().Returns(scope);
+            scopeFactory = factory;
+
+            serviceProvider.GetService(typeof(IMediaAssetRepository)).Returns(Repository);
+        }
+
+        public IdempotencyCheckMiddleware Build()
+            => new(scopeFactory, Substitute.For<ILogger<IdempotencyCheckMiddleware>>());
+    }
+
+    private static IngestionContext MakeContext(string? contentHash = null) => new()
+    {
+        Item = new SingleFileItem("/abs/photo.jpg", "photo.jpg", MediaType.Image),
+        Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        ContentHash = contentHash,
+    };
+
+    // ==========================================================================
+    // CanInvoke
+    // ==========================================================================
+
+    [Fact]
+    public void CanInvoke_WhenHashSet_ReturnsTrue()
+    {
+        new TestFixture().Build().CanInvoke(MakeContext("abc123")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanInvoke_WhenHashNull_ReturnsFalse()
+    {
+        new TestFixture().Build().CanInvoke(MakeContext(null)).Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // InvokeAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_KnownHash_DoesNotCallNextAsync()
+    {
+        var fx = new TestFixture();
+        fx.Repository.FindByHashAsync("abc123", Arg.Any<CancellationToken>())
+            .Returns(new MediaAsset());
+        var nextCalled = false;
+        Task NextAsync(IngestionContext ctx, CancellationToken ct)
+        {
+            _ = (ctx, ct);
+            nextCalled = true;
+            return Task.CompletedTask;
+        }
+
+        await fx.Build().InvokeAsync(MakeContext("abc123"), NextAsync, CancellationToken.None);
+
+        nextCalled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_UnknownHash_CallsNextAsync()
+    {
+        var fx = new TestFixture();
+        fx.Repository.FindByHashAsync("abc123", Arg.Any<CancellationToken>())
+            .Returns((MediaAsset?)null);
+        var nextCalled = false;
+        Task NextAsync(IngestionContext ctx, CancellationToken ct)
+        {
+            _ = (ctx, ct);
+            nextCalled = true;
+            return Task.CompletedTask;
+        }
+
+        await fx.Build().InvokeAsync(MakeContext("abc123"), NextAsync, CancellationToken.None);
+
+        nextCalled.Should().BeTrue();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/IdempotencyCheckMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/IdempotencyCheckMiddlewareTests.cs
@@ -3,7 +3,6 @@ using Anichron.Core.Domain;
 using Anichron.Worker.Ingestion;
 using Anichron.Worker.Ingestion.Middlewares;
 using Anichron.Worker.Ingestion.Pipeline;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Anichron.Worker.Tests.Unit.Ingestion.Middlewares;
@@ -14,23 +13,8 @@ public sealed class IdempotencyCheckMiddlewareTests
     {
         public IMediaAssetRepository Repository { get; } = Substitute.For<IMediaAssetRepository>();
 
-        private readonly IServiceScopeFactory scopeFactory;
-
-        public TestFixture()
-        {
-            var serviceProvider = Substitute.For<IServiceProvider>();
-            var scope = Substitute.For<IServiceScope>();
-            scope.ServiceProvider.Returns(serviceProvider);
-
-            var factory = Substitute.For<IServiceScopeFactory>();
-            factory.CreateScope().Returns(scope);
-            scopeFactory = factory;
-
-            serviceProvider.GetService(typeof(IMediaAssetRepository)).Returns(Repository);
-        }
-
         public IdempotencyCheckMiddleware Build()
-            => new(scopeFactory, Substitute.For<ILogger<IdempotencyCheckMiddleware>>());
+            => new(Repository, Substitute.For<ILogger<IdempotencyCheckMiddleware>>());
     }
 
     private static IngestionContext MakeContext(string? contentHash = null) => new()

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
@@ -1,6 +1,7 @@
 using Anichron.Core.Domain;
 using Anichron.Worker.Ingestion;
 using Anichron.Worker.Ingestion.Pipeline;
+using Microsoft.Extensions.Logging;
 
 namespace Anichron.Worker.Tests.Unit.Ingestion.Pipeline;
 
@@ -23,7 +24,7 @@ public sealed class IngestionPipelineBuilderTests
         var first = new OrderCapturingMiddleware(1, order);
         var second = new OrderCapturingMiddleware(2, order);
 
-        var pipeline = IngestionPipelineBuilder.Build([first, second]);
+        var pipeline = IngestionPipelineBuilder.Build([first, second], Substitute.For<ILogger>());
         await pipeline(MakeContext(), CancellationToken.None);
 
         order.Should().Equal(1, 2);
@@ -32,7 +33,7 @@ public sealed class IngestionPipelineBuilderTests
     [Fact]
     public async Task Build_EmptyPipeline_CompletesWithoutExceptionAsync()
     {
-        var pipeline = IngestionPipelineBuilder.Build([]);
+        var pipeline = IngestionPipelineBuilder.Build([], Substitute.For<ILogger>());
         var act = async () => await pipeline(MakeContext(), CancellationToken.None);
         await act.Should().NotThrowAsync();
     }
@@ -48,7 +49,7 @@ public sealed class IngestionPipelineBuilderTests
         middleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
         middleware.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError("hash is required"));
 
-        var pipeline = IngestionPipelineBuilder.Build([middleware]);
+        var pipeline = IngestionPipelineBuilder.Build([middleware], Substitute.For<ILogger>());
         var act = async () => await pipeline(MakeContext(), CancellationToken.None);
 
         await act.Should().ThrowAsync<PipelineConfigurationException>()
@@ -62,7 +63,7 @@ public sealed class IngestionPipelineBuilderTests
         middleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
         middleware.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError("missing"));
 
-        var pipeline = IngestionPipelineBuilder.Build([middleware]);
+        var pipeline = IngestionPipelineBuilder.Build([middleware], Substitute.For<ILogger>());
         var act = async () => await pipeline(MakeContext(), CancellationToken.None);
 
         await act.Should().ThrowAsync<PipelineConfigurationException>()
@@ -76,7 +77,7 @@ public sealed class IngestionPipelineBuilderTests
         middleware.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
         middleware.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError(string.Empty));
 
-        var pipeline = IngestionPipelineBuilder.Build([middleware]);
+        var pipeline = IngestionPipelineBuilder.Build([middleware], Substitute.For<ILogger>());
         try
         { await pipeline(MakeContext(), CancellationToken.None); }
         catch (PipelineConfigurationException exception) { _ = exception; }
@@ -95,7 +96,7 @@ public sealed class IngestionPipelineBuilderTests
         second.CanInvoke(Arg.Any<IngestionContext>()).Returns(false);
         second.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError(string.Empty));
 
-        var pipeline = IngestionPipelineBuilder.Build([first, second]);
+        var pipeline = IngestionPipelineBuilder.Build([first, second], Substitute.For<ILogger>());
         try
         { await pipeline(MakeContext(), CancellationToken.None); }
         catch (PipelineConfigurationException exception) { _ = exception; }

--- a/src/Anichron.Worker/Anichron.Worker.csproj
+++ b/src/Anichron.Worker/Anichron.Worker.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="MetadataExtractor" />
+    <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>
 

--- a/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
+++ b/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
@@ -14,13 +14,12 @@ internal interface IFileIngestionPipeline
 }
 
 internal sealed partial class FileIngestionPipeline(
-    IEnumerable<IIngestionMiddleware> middlewares,
+    IServiceScopeFactory scopeFactory,
     IFileSystem fileSystem,
     ILivePhotoLinker livePhotoLinker,
     IOptions<WorkerSettings> workerOptions,
     ILogger<FileIngestionPipeline> logger) : IFileIngestionPipeline
 {
-    private readonly IngestionDelegate pipeline = IngestionPipelineBuilder.Build([.. middlewares], logger);
     private readonly WorkerSettings settings = workerOptions.Value;
 
     public async Task RunAsync(UserStorageConfig config, CancellationToken ct)
@@ -98,12 +97,15 @@ internal sealed partial class FileIngestionPipeline(
         await foreach (var item in reader.ReadAllAsync(ct))
         {
             var filename = fileSystem.Path.GetFileName(item.AbsolutePath);
-            using var scope = logger.BeginScope(
+            using var logScope = logger.BeginScope(
                 "W{WorkerIndex} {IngestionFile}", workerIndex, filename);
+            // Scoped services (e.g. DbContext) must not be shared across concurrent files.
+            using var diScope = scopeFactory.CreateScope();
+            var runner = diScope.ServiceProvider.GetRequiredService<IIngestionPipelineRunner>();
             try
             {
                 var context = new IngestionContext { Item = item, Config = config };
-                await pipeline(context, ct);
+                await runner.RunAsync(context, ct);
             }
             catch (PipelineConfigurationException ex)
             {

--- a/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
+++ b/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
@@ -20,13 +20,13 @@ internal sealed partial class FileIngestionPipeline(
     IOptions<WorkerSettings> workerOptions,
     ILogger<FileIngestionPipeline> logger) : IFileIngestionPipeline
 {
-    private readonly IngestionDelegate _pipeline = IngestionPipelineBuilder.Build([.. middlewares]);
-    private readonly WorkerSettings _settings = workerOptions.Value;
+    private readonly IngestionDelegate pipeline = IngestionPipelineBuilder.Build([.. middlewares], logger);
+    private readonly WorkerSettings settings = workerOptions.Value;
 
     public async Task RunAsync(UserStorageConfig config, CancellationToken ct)
     {
         var channel = Channel.CreateBounded<IngestionItem>(
-            new BoundedChannelOptions(_settings.MaxConcurrentFiles * 2)
+            new BoundedChannelOptions(settings.MaxConcurrentFiles * 2)
             {
                 SingleWriter = true,
                 FullMode = BoundedChannelFullMode.Wait,
@@ -34,8 +34,8 @@ internal sealed partial class FileIngestionPipeline(
 
         var producer = ProduceAsync(config, channel.Writer, ct);
         var consumers = Enumerable
-            .Range(0, _settings.MaxConcurrentFiles)
-            .Select(_ => ConsumeAsync(config, channel.Reader, ct))
+            .Range(0, settings.MaxConcurrentFiles)
+            .Select(workerIndex => ConsumeAsync(config, channel.Reader, workerIndex, ct))
             .ToArray();
 
         await Task.WhenAll([producer, .. consumers]);
@@ -92,14 +92,18 @@ internal sealed partial class FileIngestionPipeline(
     private async Task ConsumeAsync(
         UserStorageConfig config,
         ChannelReader<IngestionItem> reader,
+        int workerIndex,
         CancellationToken ct)
     {
         await foreach (var item in reader.ReadAllAsync(ct))
         {
+            var filename = fileSystem.Path.GetFileName(item.AbsolutePath);
+            using var scope = logger.BeginScope(
+                "W{WorkerIndex} {IngestionFile}", workerIndex, filename);
             try
             {
                 var context = new IngestionContext { Item = item, Config = config };
-                await _pipeline(context, ct);
+                await pipeline(context, ct);
             }
             catch (PipelineConfigurationException ex)
             {

--- a/src/Anichron.Worker/Crawling/Worker.cs
+++ b/src/Anichron.Worker/Crawling/Worker.cs
@@ -12,7 +12,7 @@ internal sealed partial class Worker(
     IOptions<WorkerSettings> options,
     ILogger<Worker> logger) : BackgroundService
 {
-    private readonly WorkerSettings _settings = options.Value;
+    private readonly WorkerSettings settings = options.Value;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -24,7 +24,7 @@ internal sealed partial class Worker(
         while (!stoppingToken.IsCancellationRequested)
         {
             await CrawlAllAsync(stoppingToken);
-            await Task.Delay(TimeSpan.FromHours(_settings.CrawlIntervalHours), stoppingToken);
+            await Task.Delay(TimeSpan.FromHours(settings.CrawlIntervalHours), stoppingToken);
         }
     }
 

--- a/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
+++ b/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
@@ -1,9 +1,16 @@
+using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Infrastructure.Configuration;
 using Anichron.Worker.Crawling;
 using Anichron.Worker.Ingestion;
 using Anichron.Worker.Ingestion.Pipeline;
+using Anichron.Worker.Maintenance;
+using Anichron.Worker.Settings;
+using Anichron.Worker.Startup;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
 using System.IO.Abstractions;
+using CrawlingWorker = Anichron.Worker.Crawling.Worker;
 
 namespace Anichron.Worker.Infrastructure;
 
@@ -35,6 +42,35 @@ public static class HostApplicationBuilderExtensions
             builder.Services.AddSingleton<IFileIngestionPipeline, FileIngestionPipeline>();
             builder.Services.AddScoped<IMediaAssetRepository, EfMediaAssetRepository>();
             builder.Services.AddIngestionSteps();
+            return builder;
+        }
+
+        public HostApplicationBuilder AddWorkerCoreServices()
+        {
+            builder.Services.Configure<WorkerSettings>(builder.Configuration.GetSection("Worker"));
+            builder.Services.AddSingleton<IClock>(SystemClock.Instance);
+            builder.Services.AddSingleton<WorkerState>();
+            return builder;
+        }
+
+        public HostApplicationBuilder AddWorkerDataServices()
+        {
+            var connectionString = DatabaseConfiguration.GetConnectionString(builder.Configuration, new FileSystem());
+            builder.Services.AddDbContext<AnichronDbContext>(options =>
+                options.UseNpgsql(connectionString, o => o.UseNodaTime()));
+            builder.Services.AddScoped<IUserRepository, EfUserRepository>();
+            builder.Services.AddScoped<IUserStorageConfigRepository, EfUserStorageConfigRepository>();
+            builder.Services.AddScoped<IRefreshTokenRepository, EfRefreshTokenRepository>();
+            builder.Services.AddScoped<IDatabaseMigrator, EfDatabaseMigrator>();
+            return builder;
+        }
+
+        public HostApplicationBuilder AddWorkerHostedServices()
+        {
+            builder.Services.AddHostedService<DatabaseMigratorService>();
+            builder.Services.AddHostedService<WorkerInitializer>();
+            builder.Services.AddHostedService<TokenCleanupService>();
+            builder.Services.AddHostedService<CrawlingWorker>();
             return builder;
         }
     }

--- a/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
+++ b/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Anichron.Core.Data.Repository;
 using Anichron.Infrastructure.Configuration;
 using Anichron.Worker.Crawling;
 using Anichron.Worker.Ingestion;
@@ -32,6 +33,7 @@ public static class HostApplicationBuilderExtensions
             builder.Services.AddSingleton<IFileSystem, FileSystem>();
             builder.Services.AddSingleton<ILivePhotoLinker, LivePhotoLinker>();
             builder.Services.AddSingleton<IFileIngestionPipeline, FileIngestionPipeline>();
+            builder.Services.AddScoped<IMediaAssetRepository, EfMediaAssetRepository>();
             builder.Services.AddIngestionSteps();
             return builder;
         }

--- a/src/Anichron.Worker/Ingestion/ExifData.cs
+++ b/src/Anichron.Worker/Ingestion/ExifData.cs
@@ -12,4 +12,7 @@ internal sealed record ExifData(
     string? CameraMake,
     string? CameraModel,
     string? LensModel,
-    int? DurationInSeconds);
+    int? DurationInSeconds)
+{
+    internal static ExifData Empty { get; } = new(0, 0, 0, null, null, null, null, null, null, null);
+}

--- a/src/Anichron.Worker/Ingestion/ExifData.cs
+++ b/src/Anichron.Worker/Ingestion/ExifData.cs
@@ -7,9 +7,9 @@ internal sealed record ExifData(
     int Height,
     int OrientationDegrees,
     LocalDateTime? DateCaptured,
-    float? Latitude,
-    float? Longitude,
+    double? Latitude,
+    double? Longitude,
     string? CameraMake,
     string? CameraModel,
     string? LensModel,
-    float? DurationSeconds);
+    int? DurationInSeconds);

--- a/src/Anichron.Worker/Ingestion/MediaTypeDetector.cs
+++ b/src/Anichron.Worker/Ingestion/MediaTypeDetector.cs
@@ -4,7 +4,7 @@ namespace Anichron.Worker.Ingestion;
 
 internal static class MediaTypeDetector
 {
-    private static readonly Dictionary<string, MediaType> ExtensionMap =
+    private static readonly Dictionary<string, MediaType> extensionMap =
         new(StringComparer.OrdinalIgnoreCase)
         {
             [".jpg"] = MediaType.Image,
@@ -28,6 +28,6 @@ internal static class MediaTypeDetector
     public static MediaType? Detect(string filePath)
     {
         var extension = Path.GetExtension(filePath);
-        return ExtensionMap.TryGetValue(extension, out var type) ? type : null;
+        return extensionMap.TryGetValue(extension, out var type) ? type : null;
     }
 }

--- a/src/Anichron.Worker/Ingestion/Middlewares/ContentHashingMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/ContentHashingMiddleware.cs
@@ -1,0 +1,22 @@
+using Anichron.Worker.Ingestion.Pipeline;
+using System.Diagnostics;
+using System.IO.Abstractions;
+using System.IO.Hashing;
+
+namespace Anichron.Worker.Ingestion.Middlewares;
+
+internal sealed class ContentHashingMiddleware(IFileSystem fileSystem) : IIngestionMiddleware
+{
+    public bool CanInvoke(IngestionContext context) => true;
+
+    public IngestionStepError OnCannotInvoke(IngestionContext context) => throw new UnreachableException();
+
+    public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
+    {
+        await using var stream = fileSystem.File.OpenRead(context.Item.AbsolutePath);
+        var hasher = new XxHash64();
+        await hasher.AppendAsync(stream, ct);
+        context.ContentHash = Convert.ToHexStringLower(hasher.GetHashAndReset());
+        await next(context, ct);
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
@@ -12,6 +12,7 @@ internal sealed partial class ExifExtractionMiddleware(
     IFileSystem fileSystem,
     ILogger<ExifExtractionMiddleware> logger) : IIngestionMiddleware
 {
+    // EXIF dates use colons as date separators ("2024:07:15 13:22:01"), unlike ISO 8601.
     private static readonly LocalDateTimePattern exifDatePattern =
         LocalDateTimePattern.CreateWithInvariantCulture("yyyy:MM:dd HH:mm:ss");
 
@@ -31,81 +32,40 @@ internal sealed partial class ExifExtractionMiddleware(
         try
         {
             using var stream = fileSystem.File.OpenRead(absolutePath);
-            var directories = ImageMetadataReader.ReadMetadata(stream);
-            return BuildExifData(directories);
+            var metadataDirectories = ImageMetadataReader.ReadMetadata(stream);
+            return BuildExifData(metadataDirectories);
         }
         catch (Exception ex)
         {
             Log.ExtractionFailed(logger, absolutePath, ex);
-            return new ExifData(0, 0, 0, null, null, null, null, null, null, null);
+            return ExifData.Empty;
         }
     }
 
-    private static ExifData BuildExifData(IReadOnlyList<MetadataExtractor.Directory> directories)
+    private ExifData BuildExifData(IReadOnlyList<MetadataExtractor.Directory> metadataDirectories)
     {
-        var ifd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
-        var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
-        var gps = directories.OfType<GpsDirectory>().FirstOrDefault();
-        var trackHeader = directories.OfType<QuickTimeTrackHeaderDirectory>().FirstOrDefault();
-        var movieHeader = directories.OfType<QuickTimeMovieHeaderDirectory>().FirstOrDefault();
+        var cameraInfo = metadataDirectories.OfType<ExifIfd0Directory>().FirstOrDefault();     // IFD0: camera make/model, orientation
+        var captureDetails = metadataDirectories.OfType<ExifSubIfdDirectory>().FirstOrDefault(); // Sub-IFD: date captured, lens model
+        var gps = metadataDirectories.OfType<GpsDirectory>().FirstOrDefault();                // GPS coordinates
+        var trackHeader = metadataDirectories.OfType<QuickTimeTrackHeaderDirectory>().FirstOrDefault(); // video dimensions
+        var movieHeader = metadataDirectories.OfType<QuickTimeMovieHeaderDirectory>().FirstOrDefault(); // video duration
 
         var (latitude, longitude) = GetCoordinates(gps);
 
         return new ExifData(
-            Width: GetWidth(ifd0, trackHeader),
-            Height: GetHeight(ifd0, trackHeader),
-            OrientationDegrees: GetOrientationDegrees(ifd0),
-            DateCaptured: GetDateCaptured(subIfd),
+            Width: GetDimension(cameraInfo, ExifDirectoryBase.TagImageWidth, trackHeader, QuickTimeTrackHeaderDirectory.TagWidth),
+            Height: GetDimension(cameraInfo, ExifDirectoryBase.TagImageHeight, trackHeader, QuickTimeTrackHeaderDirectory.TagHeight),
+            OrientationDegrees: GetOrientationDegrees(cameraInfo),
+            DateCaptured: GetDateCaptured(captureDetails),
             Latitude: latitude,
             Longitude: longitude,
-            CameraMake: ifd0?.GetString(ExifDirectoryBase.TagMake),
-            CameraModel: ifd0?.GetString(ExifDirectoryBase.TagModel),
-            LensModel: subIfd?.GetString(ExifDirectoryBase.TagLensModel),
+            CameraMake: cameraInfo?.GetString(ExifDirectoryBase.TagMake),
+            CameraModel: cameraInfo?.GetString(ExifDirectoryBase.TagModel),
+            LensModel: captureDetails?.GetString(ExifDirectoryBase.TagLensModel),
             DurationInSeconds: GetDurationInSeconds(movieHeader));
     }
 
-    private static int GetWidth(ExifIfd0Directory? ifd0, QuickTimeTrackHeaderDirectory? trackHeader)
-    {
-        if (ifd0 is not null && ifd0.TryGetInt32(ExifDirectoryBase.TagImageWidth, out var w) && w > 0)
-            return w;
-        if (trackHeader is not null && trackHeader.TryGetInt32(QuickTimeTrackHeaderDirectory.TagWidth, out var qtW) && qtW > 0)
-            return qtW;
-        return 0;
-    }
-
-    private static int GetHeight(ExifIfd0Directory? ifd0, QuickTimeTrackHeaderDirectory? trackHeader)
-    {
-        if (ifd0 is not null && ifd0.TryGetInt32(ExifDirectoryBase.TagImageHeight, out var h) && h > 0)
-            return h;
-        if (trackHeader is not null && trackHeader.TryGetInt32(QuickTimeTrackHeaderDirectory.TagHeight, out var qtH) && qtH > 0)
-            return qtH;
-        return 0;
-    }
-
-    private static int GetOrientationDegrees(ExifIfd0Directory? ifd0)
-    {
-        if (ifd0 is null || !ifd0.TryGetInt32(ExifDirectoryBase.TagOrientation, out var orientation))
-            return 0;
-        return orientation switch
-        {
-            1 => 0,
-            6 => 90,
-            3 => 180,
-            8 => 270,
-            _ => 0,
-        };
-    }
-
-    private static LocalDateTime? GetDateCaptured(ExifSubIfdDirectory? subIfd)
-    {
-        var raw = subIfd?.GetString(ExifDirectoryBase.TagDateTimeOriginal);
-        if (raw is null)
-            return null;
-        var result = exifDatePattern.Parse(raw);
-        return result.Success ? result.Value : null;
-    }
-
-    private static (double? Latitude, double? Longitude) GetCoordinates(GpsDirectory? gps)
+    private (double? Latitude, double? Longitude) GetCoordinates(GpsDirectory? gps)
     {
         if (gps is null)
             return (null, null);
@@ -114,19 +74,61 @@ internal sealed partial class ExifExtractionMiddleware(
             var location = gps.GetGeoLocation();
             return location is null ? (null, null) : (location.Latitude, location.Longitude);
         }
-        catch
+        catch (Exception ex)
         {
+            Log.GpsCoordinatesParseFailed(logger, ex);
             return (null, null);
         }
+    }
+
+    // Photos embed dimensions in EXIF IFD0; videos only have QuickTime track headers.
+    // Trying EXIF first covers both formats with a single helper.
+    private static int GetDimension(
+        MetadataExtractor.Directory? exifDirectory, int exifTag,
+        QuickTimeTrackHeaderDirectory? trackHeader, int quickTimeTag)
+    {
+        // Each check: segment present AND tag readable AND value is a valid positive dimension.
+        if (exifDirectory is not null && exifDirectory.TryGetInt32(exifTag, out var exifPixels) && exifPixels > 0)
+            return exifPixels;
+        if (trackHeader is not null && trackHeader.TryGetInt32(quickTimeTag, out var qtPixels) && qtPixels > 0)
+            return qtPixels;
+        return 0;
+    }
+
+    private static int GetOrientationDegrees(ExifIfd0Directory? cameraInfo)
+    {
+        // Segment absent OR tag unreadable — assume upright (0°).
+        if (cameraInfo is null || !cameraInfo.TryGetInt32(ExifDirectoryBase.TagOrientation, out var orientation))
+            return 0;
+        // Raw EXIF orientation tag values per the EXIF 2.3 spec.
+        // Only rotations (no mirroring) are represented; mirrored variants map to 0.
+        return orientation switch
+        {
+            6 => 90,
+            3 => 180,
+            8 => 270,
+            _ => 0,
+        };
+    }
+
+    private LocalDateTime? GetDateCaptured(ExifSubIfdDirectory? captureDetails)
+    {
+        var raw = captureDetails?.GetString(ExifDirectoryBase.TagDateTimeOriginal);
+        if (raw is null)
+            return null;
+        var result = exifDatePattern.Parse(raw);
+        if (!result.Success)
+            Log.DateParseFailed(logger, raw);
+        return result.Success ? result.Value : null;
     }
 
     private static int? GetDurationInSeconds(QuickTimeMovieHeaderDirectory? movieHeader)
     {
         if (movieHeader is null)
             return null;
-        if (!movieHeader.TryGetInt64(QuickTimeMovieHeaderDirectory.TagDuration, out var duration) ||
-            !movieHeader.TryGetInt32(QuickTimeMovieHeaderDirectory.TagTimeScale, out var timeScale) ||
-            timeScale <= 0)
+        if (!movieHeader.TryGetInt64(QuickTimeMovieHeaderDirectory.TagDuration, out var duration) ||    // tag absent or unreadable
+            !movieHeader.TryGetInt32(QuickTimeMovieHeaderDirectory.TagTimeScale, out var timeScale) ||  // tag absent or unreadable
+            timeScale <= 0)                                                                             // guard: prevents division by zero
         {
             return null;
         }
@@ -138,5 +140,11 @@ internal sealed partial class ExifExtractionMiddleware(
     {
         [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to extract EXIF metadata from {Path}.")]
         public static partial void ExtractionFailed(ILogger logger, string path, Exception exception);
+
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to parse GPS coordinates from EXIF data.")]
+        public static partial void GpsCoordinatesParseFailed(ILogger logger, Exception exception);
+
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Failed to parse EXIF date '{Raw}'.")]
+        public static partial void DateParseFailed(ILogger logger, string raw);
     }
 }

--- a/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
@@ -1,0 +1,142 @@
+using Anichron.Worker.Ingestion.Pipeline;
+using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.QuickTime;
+using NodaTime;
+using NodaTime.Text;
+using System.IO.Abstractions;
+
+namespace Anichron.Worker.Ingestion.Middlewares;
+
+internal sealed partial class ExifExtractionMiddleware(
+    IFileSystem fileSystem,
+    ILogger<ExifExtractionMiddleware> logger) : IIngestionMiddleware
+{
+    private static readonly LocalDateTimePattern exifDatePattern =
+        LocalDateTimePattern.CreateWithInvariantCulture("yyyy:MM:dd HH:mm:ss");
+
+    public bool CanInvoke(IngestionContext context) => context.ContentHash is not null;
+
+    public IngestionStepError OnCannotInvoke(IngestionContext context)
+        => new("ContentHash must be set before EXIF extraction");
+
+    public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
+    {
+        context.Exif = ExtractExif(context.Item.AbsolutePath);
+        await next(context, ct);
+    }
+
+    private ExifData ExtractExif(string absolutePath)
+    {
+        try
+        {
+            using var stream = fileSystem.File.OpenRead(absolutePath);
+            var directories = ImageMetadataReader.ReadMetadata(stream);
+            return BuildExifData(directories);
+        }
+        catch (Exception ex)
+        {
+            Log.ExtractionFailed(logger, absolutePath, ex);
+            return new ExifData(0, 0, 0, null, null, null, null, null, null, null);
+        }
+    }
+
+    private static ExifData BuildExifData(IReadOnlyList<MetadataExtractor.Directory> directories)
+    {
+        var ifd0 = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
+        var subIfd = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
+        var gps = directories.OfType<GpsDirectory>().FirstOrDefault();
+        var trackHeader = directories.OfType<QuickTimeTrackHeaderDirectory>().FirstOrDefault();
+        var movieHeader = directories.OfType<QuickTimeMovieHeaderDirectory>().FirstOrDefault();
+
+        var (latitude, longitude) = GetCoordinates(gps);
+
+        return new ExifData(
+            Width: GetWidth(ifd0, trackHeader),
+            Height: GetHeight(ifd0, trackHeader),
+            OrientationDegrees: GetOrientationDegrees(ifd0),
+            DateCaptured: GetDateCaptured(subIfd),
+            Latitude: latitude,
+            Longitude: longitude,
+            CameraMake: ifd0?.GetString(ExifDirectoryBase.TagMake),
+            CameraModel: ifd0?.GetString(ExifDirectoryBase.TagModel),
+            LensModel: subIfd?.GetString(ExifDirectoryBase.TagLensModel),
+            DurationSeconds: GetDurationSeconds(movieHeader));
+    }
+
+    private static int GetWidth(ExifIfd0Directory? ifd0, QuickTimeTrackHeaderDirectory? trackHeader)
+    {
+        if (ifd0 is not null && ifd0.TryGetInt32(ExifDirectoryBase.TagImageWidth, out var w) && w > 0)
+            return w;
+        if (trackHeader is not null && trackHeader.TryGetInt32(QuickTimeTrackHeaderDirectory.TagWidth, out var qtW) && qtW > 0)
+            return qtW;
+        return 0;
+    }
+
+    private static int GetHeight(ExifIfd0Directory? ifd0, QuickTimeTrackHeaderDirectory? trackHeader)
+    {
+        if (ifd0 is not null && ifd0.TryGetInt32(ExifDirectoryBase.TagImageHeight, out var h) && h > 0)
+            return h;
+        if (trackHeader is not null && trackHeader.TryGetInt32(QuickTimeTrackHeaderDirectory.TagHeight, out var qtH) && qtH > 0)
+            return qtH;
+        return 0;
+    }
+
+    private static int GetOrientationDegrees(ExifIfd0Directory? ifd0)
+    {
+        if (ifd0 is null || !ifd0.TryGetInt32(ExifDirectoryBase.TagOrientation, out var orientation))
+            return 0;
+        return orientation switch
+        {
+            1 => 0,
+            6 => 90,
+            3 => 180,
+            8 => 270,
+            _ => 0,
+        };
+    }
+
+    private static LocalDateTime? GetDateCaptured(ExifSubIfdDirectory? subIfd)
+    {
+        var raw = subIfd?.GetString(ExifDirectoryBase.TagDateTimeOriginal);
+        if (raw is null)
+            return null;
+        var result = exifDatePattern.Parse(raw);
+        return result.Success ? result.Value : null;
+    }
+
+    private static (float? Latitude, float? Longitude) GetCoordinates(GpsDirectory? gps)
+    {
+        if (gps is null)
+            return (null, null);
+        try
+        {
+            var location = gps.GetGeoLocation();
+            return location is null ? (null, null) : ((float)location.Latitude, (float)location.Longitude);
+        }
+        catch
+        {
+            return (null, null);
+        }
+    }
+
+    private static float? GetDurationSeconds(QuickTimeMovieHeaderDirectory? movieHeader)
+    {
+        if (movieHeader is null)
+            return null;
+        if (!movieHeader.TryGetInt32(QuickTimeMovieHeaderDirectory.TagDuration, out var duration) ||
+            !movieHeader.TryGetInt32(QuickTimeMovieHeaderDirectory.TagTimeScale, out var timeScale) ||
+            timeScale <= 0)
+        {
+            return null;
+        }
+
+        return (float)duration / timeScale;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to extract EXIF metadata from {Path}.")]
+        public static partial void ExtractionFailed(ILogger logger, string path, Exception exception);
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
@@ -61,7 +61,7 @@ internal sealed partial class ExifExtractionMiddleware(
             CameraMake: ifd0?.GetString(ExifDirectoryBase.TagMake),
             CameraModel: ifd0?.GetString(ExifDirectoryBase.TagModel),
             LensModel: subIfd?.GetString(ExifDirectoryBase.TagLensModel),
-            DurationSeconds: GetDurationSeconds(movieHeader));
+            DurationInSeconds: GetDurationInSeconds(movieHeader));
     }
 
     private static int GetWidth(ExifIfd0Directory? ifd0, QuickTimeTrackHeaderDirectory? trackHeader)
@@ -105,14 +105,14 @@ internal sealed partial class ExifExtractionMiddleware(
         return result.Success ? result.Value : null;
     }
 
-    private static (float? Latitude, float? Longitude) GetCoordinates(GpsDirectory? gps)
+    private static (double? Latitude, double? Longitude) GetCoordinates(GpsDirectory? gps)
     {
         if (gps is null)
             return (null, null);
         try
         {
             var location = gps.GetGeoLocation();
-            return location is null ? (null, null) : ((float)location.Latitude, (float)location.Longitude);
+            return location is null ? (null, null) : (location.Latitude, location.Longitude);
         }
         catch
         {
@@ -120,18 +120,18 @@ internal sealed partial class ExifExtractionMiddleware(
         }
     }
 
-    private static float? GetDurationSeconds(QuickTimeMovieHeaderDirectory? movieHeader)
+    private static int? GetDurationInSeconds(QuickTimeMovieHeaderDirectory? movieHeader)
     {
         if (movieHeader is null)
             return null;
-        if (!movieHeader.TryGetInt32(QuickTimeMovieHeaderDirectory.TagDuration, out var duration) ||
+        if (!movieHeader.TryGetInt64(QuickTimeMovieHeaderDirectory.TagDuration, out var duration) ||
             !movieHeader.TryGetInt32(QuickTimeMovieHeaderDirectory.TagTimeScale, out var timeScale) ||
             timeScale <= 0)
         {
             return null;
         }
 
-        return (float)duration / timeScale;
+        return (int)Math.Round((double)duration / timeScale);
     }
 
     private static partial class Log

--- a/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/ExifExtractionMiddleware.cs
@@ -87,7 +87,7 @@ internal sealed partial class ExifExtractionMiddleware(
         MetadataExtractor.Directory? exifDirectory, int exifTag,
         QuickTimeTrackHeaderDirectory? trackHeader, int quickTimeTag)
     {
-        // Each check: segment present AND tag readable AND value is a valid positive dimension.
+        // Each check below: segment present AND tag readable AND value is a valid positive dimension.
         if (exifDirectory is not null && exifDirectory.TryGetInt32(exifTag, out var exifPixels) && exifPixels > 0)
             return exifPixels;
         if (trackHeader is not null && trackHeader.TryGetInt32(quickTimeTag, out var qtPixels) && qtPixels > 0)
@@ -128,7 +128,8 @@ internal sealed partial class ExifExtractionMiddleware(
             return null;
         if (!movieHeader.TryGetInt64(QuickTimeMovieHeaderDirectory.TagDuration, out var duration) ||    // tag absent or unreadable
             !movieHeader.TryGetInt32(QuickTimeMovieHeaderDirectory.TagTimeScale, out var timeScale) ||  // tag absent or unreadable
-            timeScale <= 0)                                                                             // guard: prevents division by zero
+            timeScale <= 0 ||                                                                           // guard: prevents division by zero
+            duration < 0)                                                                               // guard: malformed negative duration
         {
             return null;
         }

--- a/src/Anichron.Worker/Ingestion/Middlewares/IdempotencyCheckMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/IdempotencyCheckMiddleware.cs
@@ -4,7 +4,7 @@ using Anichron.Worker.Ingestion.Pipeline;
 namespace Anichron.Worker.Ingestion.Middlewares;
 
 internal sealed partial class IdempotencyCheckMiddleware(
-    IServiceScopeFactory scopeFactory,
+    IMediaAssetRepository repository,
     ILogger<IdempotencyCheckMiddleware> logger) : IIngestionMiddleware
 {
     public bool CanInvoke(IngestionContext context) => context.ContentHash is not null;
@@ -14,9 +14,7 @@ internal sealed partial class IdempotencyCheckMiddleware(
 
     public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
     {
-        using var scope = scopeFactory.CreateScope();
-        var repository = scope.ServiceProvider.GetRequiredService<IMediaAssetRepository>();
-        var existing = await repository.FindByHashAsync(context.ContentHash!, ct); // CanInvoke verified not null
+        var existing = await repository.FindByHashAsync(context.ContentHash!, ct);
         if (existing is not null)
         {
             Log.AlreadyIngested(logger, context.Item.AbsolutePath);

--- a/src/Anichron.Worker/Ingestion/Middlewares/IdempotencyCheckMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/IdempotencyCheckMiddleware.cs
@@ -1,0 +1,34 @@
+using Anichron.Core.Data.Repository;
+using Anichron.Worker.Ingestion.Pipeline;
+
+namespace Anichron.Worker.Ingestion.Middlewares;
+
+internal sealed partial class IdempotencyCheckMiddleware(
+    IServiceScopeFactory scopeFactory,
+    ILogger<IdempotencyCheckMiddleware> logger) : IIngestionMiddleware
+{
+    public bool CanInvoke(IngestionContext context) => context.ContentHash is not null;
+
+    public IngestionStepError OnCannotInvoke(IngestionContext context)
+        => new("ContentHash must be set before idempotency check");
+
+    public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IMediaAssetRepository>();
+        var existing = await repository.FindByHashAsync(context.ContentHash!, ct); // CanInvoke verified not null
+        if (existing is not null)
+        {
+            Log.AlreadyIngested(logger, context.Item.AbsolutePath);
+            return;
+        }
+
+        await next(context, ct);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Already ingested {Path}, skipping.")]
+        public static partial void AlreadyIngested(ILogger logger, string path);
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Middlewares/IdempotencyCheckMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/IdempotencyCheckMiddleware.cs
@@ -14,6 +14,7 @@ internal sealed partial class IdempotencyCheckMiddleware(
 
     public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
     {
+        // CanInvoke guards ContentHash != null; suppression is safe.
         var existing = await repository.FindByHashAsync(context.ContentHash!, ct);
         if (existing is not null)
         {

--- a/src/Anichron.Worker/Ingestion/Pipeline/IIngestionMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IIngestionMiddleware.cs
@@ -4,6 +4,7 @@ internal delegate Task IngestionDelegate(IngestionContext context, CancellationT
 
 internal interface IIngestionMiddleware
 {
+    string StepName => GetType().Name;
     bool CanInvoke(IngestionContext context);
     IngestionStepError OnCannotInvoke(IngestionContext context);
     Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct);

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
@@ -1,8 +1,8 @@
 namespace Anichron.Worker.Ingestion.Pipeline;
 
-internal static class IngestionPipelineBuilder
+internal static partial class IngestionPipelineBuilder
 {
-    internal static IngestionDelegate Build(IReadOnlyList<IIngestionMiddleware> middlewares)
+    internal static IngestionDelegate Build(IReadOnlyList<IIngestionMiddleware> middlewares, ILogger logger)
     {
         IngestionDelegate pipeline = static (_, _) => Task.CompletedTask;
 
@@ -20,13 +20,20 @@ internal static class IngestionPipelineBuilder
                 {
                     var error = current.OnCannotInvoke(context);
                     throw new PipelineConfigurationException(
-                        $"{current.GetType().Name} cannot invoke: {error.Message}");
+                        $"{current.StepName} cannot invoke: {error.Message}");
                 }
 
+                Log.StepStarted(logger, current.StepName);
                 await current.InvokeAsync(context, next, ct);
             };
         }
 
         return pipeline;
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Debug, Message = "→ {MiddlewareName}")]
+        public static partial void StepStarted(ILogger logger, string middlewareName);
     }
 }

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineBuilder.cs
@@ -33,7 +33,7 @@ internal static partial class IngestionPipelineBuilder
 
     private static partial class Log
     {
-        [LoggerMessage(Level = LogLevel.Debug, Message = "→ {MiddlewareName}")]
+        [LoggerMessage(Level = LogLevel.Debug, Message = "-> {MiddlewareName}")]
         public static partial void StepStarted(ILogger logger, string middlewareName);
     }
 }

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineRunner.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionPipelineRunner.cs
@@ -1,0 +1,15 @@
+namespace Anichron.Worker.Ingestion.Pipeline;
+
+internal interface IIngestionPipelineRunner
+{
+    Task RunAsync(IngestionContext context, CancellationToken ct);
+}
+
+internal sealed class IngestionPipelineRunner(
+    IEnumerable<IIngestionMiddleware> middlewares,
+    ILogger<IngestionPipelineRunner> logger) : IIngestionPipelineRunner
+{
+    private readonly IngestionDelegate pipeline = IngestionPipelineBuilder.Build([.. middlewares], logger);
+
+    public Task RunAsync(IngestionContext context, CancellationToken ct) => pipeline(context, ct);
+}

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
@@ -4,12 +4,13 @@ namespace Anichron.Worker.Ingestion.Pipeline;
 
 internal static class IngestionServiceCollectionExtensions
 {
-    public static IServiceCollection AddIngestionSteps(this IServiceCollection services)
+    internal static IServiceCollection AddIngestionSteps(this IServiceCollection services)
     {
-        services.AddSingleton<IIngestionMiddleware, LoggingMiddleware>();
-        services.AddSingleton<IIngestionMiddleware, ContentHashingMiddleware>();
-        services.AddSingleton<IIngestionMiddleware, IdempotencyCheckMiddleware>();
-        services.AddSingleton<IIngestionMiddleware, ExifExtractionMiddleware>();
+        services.AddScoped<IIngestionMiddleware, LoggingMiddleware>();
+        services.AddScoped<IIngestionMiddleware, ContentHashingMiddleware>();
+        services.AddScoped<IIngestionMiddleware, IdempotencyCheckMiddleware>();
+        services.AddScoped<IIngestionMiddleware, ExifExtractionMiddleware>();
+        services.AddScoped<IIngestionPipelineRunner, IngestionPipelineRunner>();
         return services;
     }
 }

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
@@ -7,6 +7,9 @@ internal static class IngestionServiceCollectionExtensions
     public static IServiceCollection AddIngestionSteps(this IServiceCollection services)
     {
         services.AddSingleton<IIngestionMiddleware, LoggingMiddleware>();
+        services.AddSingleton<IIngestionMiddleware, ContentHashingMiddleware>();
+        services.AddSingleton<IIngestionMiddleware, IdempotencyCheckMiddleware>();
+        services.AddSingleton<IIngestionMiddleware, ExifExtractionMiddleware>();
         return services;
     }
 }

--- a/src/Anichron.Worker/Maintenance/TokenCleanupService.cs
+++ b/src/Anichron.Worker/Maintenance/TokenCleanupService.cs
@@ -11,11 +11,11 @@ public sealed partial class TokenCleanupService(
     IOptions<WorkerSettings> options,
     ILogger<TokenCleanupService> logger) : BackgroundService
 {
-    private readonly WorkerSettings _settings = options.Value;
+    private readonly WorkerSettings settings = options.Value;
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        using var timer = new PeriodicTimer(TimeSpan.FromHours(_settings.TokenCleanupIntervalHours));
+        using var timer = new PeriodicTimer(TimeSpan.FromHours(settings.TokenCleanupIntervalHours));
         do
         {
             try

--- a/src/Anichron.Worker/Program.cs
+++ b/src/Anichron.Worker/Program.cs
@@ -1,34 +1,10 @@
-using Anichron.Core.Data;
-using Anichron.Core.Data.Repository;
-using Anichron.Infrastructure.Configuration;
-using Anichron.Worker.Crawling;
 using Anichron.Worker.Infrastructure;
-using Anichron.Worker.Maintenance;
-using Anichron.Worker.Settings;
-using Anichron.Worker.Startup;
-using Microsoft.EntityFrameworkCore;
-using NodaTime;
-using System.IO.Abstractions;
 
 var builder = Host.CreateApplicationBuilder(args);
 builder.AddAppConfiguration();
+builder.AddWorkerCoreServices();
+builder.AddWorkerDataServices();
 builder.AddIngestionServices();
-
-builder.Services.Configure<WorkerSettings>(builder.Configuration.GetSection("Worker"));
-builder.Services.AddSingleton<IClock>(SystemClock.Instance);
-builder.Services.AddSingleton<WorkerState>();
-builder.Services.AddScoped<IUserRepository, EfUserRepository>();
-builder.Services.AddScoped<IUserStorageConfigRepository, EfUserStorageConfigRepository>();
-builder.Services.AddScoped<IRefreshTokenRepository, EfRefreshTokenRepository>();
-builder.Services.AddScoped<IDatabaseMigrator, EfDatabaseMigrator>();
-
-var databaseConnection = DatabaseConfiguration.GetConnectionString(builder.Configuration, new FileSystem());
-builder.Services.AddDbContext<AnichronDbContext>(options =>
-    options.UseNpgsql(databaseConnection, o => o.UseNodaTime()));
-
-builder.Services.AddHostedService<DatabaseMigratorService>();
-builder.Services.AddHostedService<WorkerInitializer>();
-builder.Services.AddHostedService<TokenCleanupService>();
-builder.Services.AddHostedService<Worker>();
+builder.AddWorkerHostedServices();
 
 await builder.Build().RunAsync();

--- a/src/Anichron.Worker/Startup/WorkerInitializer.cs
+++ b/src/Anichron.Worker/Startup/WorkerInitializer.cs
@@ -13,11 +13,11 @@ public sealed partial class WorkerInitializer(
     WorkerState workerState,
     ILogger<WorkerInitializer> logger) : IHostedService
 {
-    private readonly WorkerSettings _settings = options.Value;
+    private readonly WorkerSettings settings = options.Value;
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        if (string.IsNullOrWhiteSpace(_settings.User))
+        if (string.IsNullOrWhiteSpace(settings.User))
         {
             Log.AllUserMode(logger);
             return;
@@ -28,21 +28,21 @@ public sealed partial class WorkerInitializer(
         var storageConfigRepository = scope.ServiceProvider.GetRequiredService<IUserStorageConfigRepository>();
         var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
 
-        var credential = _settings.User.Trim().ToLowerInvariant();
+        var credential = settings.User.Trim().ToLowerInvariant();
         var user = await userRepository.FindByCredentialAsync(credential, cancellationToken)
             ?? throw new InvalidOperationException(
-                $"WORKER__USER '{_settings.User}' not found in database.");
+                $"WORKER__USER '{settings.User}' not found in database.");
 
-        var existing = await storageConfigRepository.FindByRootPathAsync(_settings.RootPath, cancellationToken);
+        var existing = await storageConfigRepository.FindByRootPathAsync(settings.RootPath, cancellationToken);
         if (existing is not null)
         {
             if (existing.UserId != user.Id)
             {
                 throw new InvalidOperationException(
-                    $"Path '{_settings.RootPath}' is already assigned to another user.");
+                    $"Path '{settings.RootPath}' is already assigned to another user.");
             }
 
-            Log.StorageConfigExists(logger, user.Username, _settings.RootPath);
+            Log.StorageConfigExists(logger, user.Username, settings.RootPath);
             workerState.ResolvedUserId = user.Id;
             return;
         }
@@ -51,12 +51,12 @@ public sealed partial class WorkerInitializer(
         {
             Id = Guid.NewGuid(),
             UserId = user.Id,
-            RootPath = _settings.RootPath,
+            RootPath = settings.RootPath,
             IsActive = true,
         });
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
-        Log.StorageConfigCreated(logger, user.Username, _settings.RootPath);
+        Log.StorageConfigCreated(logger, user.Username, settings.RootPath);
         workerState.ResolvedUserId = user.Id;
     }
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,6 +5,8 @@
   </PropertyGroup>
   <ItemGroup Label="Production dependencies">
     <PackageVersion Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
+    <PackageVersion Include="MetadataExtractor" Version="2.8.1" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />


### PR DESCRIPTION
## Summary

- **Content hashing** (`ContentHashingMiddleware`) — streams each file through `XxHash64.AppendAsync` with O(1) memory regardless of file size; result stored as lowercase hex in `IngestionContext.ContentHash`
- **Idempotency check** (`IdempotencyCheckMiddleware`) — queries `IMediaAssetRepository.FindByHashAsync`; short-circuits the pipeline early if the file was already ingested, preventing duplicate DB writes
- **EXIF extraction** (`ExifExtractionMiddleware`) — reads width/height, orientation (mapped to degrees), capture date (NodaTime `LocalDateTime`), GPS coordinates, camera make/model/lens, and QuickTime video duration via MetadataExtractor; safe defaults on failure
- **Scoped pipeline execution** (`IngestionPipelineRunner`) — middlewares registered as `Scoped`; a fresh DI scope is created per file in `ConsumeAsync`, eliminating the service-locator pattern that `IdempotencyCheckMiddleware` previously required (`IServiceScopeFactory` → direct `IMediaAssetRepository` injection)
- **Structured observability** — `BeginScope` with `W{WorkerIndex}` and `{IngestionFile}` stamped on every log line produced while processing an item; pipeline builder logs `→ {MiddlewareName}` before each step; `StepName` is a default interface property so all future middlewares are covered automatically
- **`IIngestionMiddleware.StepName`** — default interface property (`GetType().Name`); overridable for a friendlier label; used by the builder and exception messages so the dependency contract is self-describing
- Added `MediaAssetRepository` + `IMediaAssetRepository` to `Anichron.Core`
- Added `MetadataExtractor` 2.8.1 and `System.IO.Hashing` 10.0.0

## Test plan

- [ ] `ContentHashingMiddlewareTests` — CanInvoke always true; next called; non-empty hash set; same content → same hash; different content → different hash
- [ ] `IdempotencyCheckMiddlewareTests` — CanInvoke guards null hash; known hash short-circuits; unknown hash calls next
- [ ] `ExifExtractionMiddlewareTests` — CanInvoke guards null hash; next always called; dimensions extracted correctly; orientation 6 → 90°; missing EXIF → safe defaults
- [ ] `IngestionPipelineBuilderTests` — registration order preserved; empty pipeline; `CanInvoke=false` throws `PipelineConfigurationException` with middleware name + error message; `InvokeAsync` never called when guard fails; first middleware still runs when second cannot invoke
- [ ] `FileIngestionPipelineTests` — live photo pairing; unsupported file skipping; `PipelineConfigurationException` propagates; relative path correctness; cross-directory isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)