### PR TITLE
chore: configure Dependabot grouped updates and patch-version filter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    groups:
+      nuget:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
 
   - package-ecosystem: docker
     directory: /src/Anichron.API
@@ -24,3 +32,11 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: dotnet build src/
 
       - name: Test
-        run: dotnet test src/ --no-build --collect:"XPlat Code Coverage" --results-directory coverage
+        run: dotnet test src/ --no-build --collect:"XPlat Code Coverage" --results-directory coverage --settings src/coverlet.runsettings
 
       - name: Generate coverage report
         uses: danielpalme/ReportGenerator-GitHub-Action@v5

--- a/src/coverlet.runsettings
+++ b/src/coverlet.runsettings
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Exclude>[Anichron.Core]Anichron.Core.Migrations.*,[Anichron.API]Microsoft.AspNetCore.OpenApi.Generated.*</Exclude>
+          <ExcludeByAttribute>GeneratedCode,CompilerGenerated</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary

- Group all NuGet updates into a single weekly PR (instead of one per package)
- Group all GitHub Actions updates into a single weekly PR
- Ignore patch-level version bumps (`x.y.Z`) — security updates bypass ignore rules and will always open a PR regardless

## Why

7 individual Dependabot PRs were open (#137–#143), all patch bumps (`10.0.7 → 10.0.8`, etc.). With this config they would have been skipped, and the two meaningful updates (`FluentAssertions` minor + the Actions major bumps) would have been batched into two grouped PRs.