### PR TITLE
test: extend unit test coverage for repositories, ExifData, and pipeline

### DIFF
--- a/src/Anichron.Core.Tests.Unit/Data/Repository/InviteRepositoryTests.cs
+++ b/src/Anichron.Core.Tests.Unit/Data/Repository/InviteRepositoryTests.cs
@@ -1,0 +1,105 @@
+using Anichron.Core.Data;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+namespace Anichron.Core.Tests.Unit.Data.Repository;
+
+public sealed class InviteRepositoryTests
+{
+    private static readonly Instant Epoch = Instant.FromUtc(2024, 1, 1, 0, 0);
+
+    private static AnichronDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AnichronDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AnichronDbContext(options);
+    }
+
+    private static Invite MakeInvite(string hash = "tok", Instant? expiresAt = null, Instant? usedAt = null)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            TokenHash = hash,
+            CreatedAt = Epoch,
+            ExpiresAt = expiresAt ?? (Epoch + Duration.FromDays(7)),
+            UsedAt = usedAt,
+        };
+
+    // ==========================================================================
+    // FindValidByHashAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindValidByHashAsync_ValidToken_ReturnsInvite()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var invite = MakeInvite("validhash");
+        db.Invites.Add(invite);
+        await db.SaveChangesAsync(ct);
+
+        var result = await new EfInviteRepository(db).FindValidByHashAsync("validhash", Epoch, ct);
+
+        result.Should().NotBeNull();
+        result.Id.Should().Be(invite.Id);
+    }
+
+    [Fact]
+    public async Task FindValidByHashAsync_ExpiredToken_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.Invites.Add(MakeInvite("expiredhash", expiresAt: Epoch - Duration.FromSeconds(1)));
+        await db.SaveChangesAsync(ct);
+
+        var result = await new EfInviteRepository(db).FindValidByHashAsync("expiredhash", Epoch, ct);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindValidByHashAsync_AlreadyUsedToken_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.Invites.Add(MakeInvite("usedhash", usedAt: Epoch - Duration.FromDays(1)));
+        await db.SaveChangesAsync(ct);
+
+        var result = await new EfInviteRepository(db).FindValidByHashAsync("usedhash", Epoch, ct);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindValidByHashAsync_UnknownHash_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        var result = await new EfInviteRepository(db).FindValidByHashAsync("nope", Epoch, ct);
+
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // Add
+    // ==========================================================================
+
+    [Fact]
+    public async Task Add_AddsInviteToContext()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var invite = MakeInvite("newinvite");
+        var repository = new EfInviteRepository(db);
+
+        repository.Add(invite);
+        await db.SaveChangesAsync(ct);
+
+        var found = await repository.FindValidByHashAsync("newinvite", Epoch, ct);
+        found.Should().NotBeNull();
+    }
+}

--- a/src/Anichron.Core.Tests.Unit/Data/Repository/RefreshTokenRepositoryTests.cs
+++ b/src/Anichron.Core.Tests.Unit/Data/Repository/RefreshTokenRepositoryTests.cs
@@ -83,7 +83,8 @@ public sealed class RefreshTokenRepositoryTests
 
         var result = await new EfRefreshTokenRepository(db).FindByHashAsync("tok2", ct);
 
-        result!.Id.Should().Be(token.Id);
+        result.Should().NotBeNull();
+        result.Id.Should().Be(token.Id);
     }
 
     [Fact]

--- a/src/Anichron.Core.Tests.Unit/Data/Repository/RefreshTokenRepositoryTests.cs
+++ b/src/Anichron.Core.Tests.Unit/Data/Repository/RefreshTokenRepositoryTests.cs
@@ -1,0 +1,121 @@
+using Anichron.Core.Data;
+using Anichron.Core.Data.Repository;
+using Anichron.Core.Domain;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
+
+namespace Anichron.Core.Tests.Unit.Data.Repository;
+
+public sealed class RefreshTokenRepositoryTests
+{
+    private static readonly Instant Epoch = Instant.FromUtc(2024, 1, 1, 0, 0);
+
+    private static AnichronDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AnichronDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new AnichronDbContext(options);
+    }
+
+    private static User MakeUser(string username = "alice")
+        => new() { Id = Guid.NewGuid(), Username = username, Email = $"{username}@example.com", PasswordHash = "hash" };
+
+    private static RefreshToken MakeToken(Guid userId, string hash = "abc", Instant? revokedAt = null)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            TokenHash = hash,
+            CreatedAt = Epoch,
+            ExpiresAt = Epoch + Duration.FromDays(30),
+            RevokedAt = revokedAt,
+        };
+
+    // ==========================================================================
+    // FindByHashWithUserAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindByHashWithUserAsync_KnownHash_ReturnsTokenWithUserLoaded()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        db.RefreshTokens.Add(MakeToken(user.Id, "tok1"));
+        await db.SaveChangesAsync(ct);
+
+        var result = await new EfRefreshTokenRepository(db).FindByHashWithUserAsync("tok1", ct);
+
+        result.Should().NotBeNull();
+        result.User.Should().NotBeNull();
+        result.User.Id.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task FindByHashWithUserAsync_UnknownHash_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        var result = await new EfRefreshTokenRepository(db).FindByHashWithUserAsync("nope", ct);
+
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // FindByHashAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindByHashAsync_KnownHash_ReturnsToken()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var token = MakeToken(user.Id, "tok2");
+        db.RefreshTokens.Add(token);
+        await db.SaveChangesAsync(ct);
+
+        var result = await new EfRefreshTokenRepository(db).FindByHashAsync("tok2", ct);
+
+        result!.Id.Should().Be(token.Id);
+    }
+
+    [Fact]
+    public async Task FindByHashAsync_UnknownHash_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+
+        var result = await new EfRefreshTokenRepository(db).FindByHashAsync("nope", ct);
+
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // Add
+    // ==========================================================================
+
+    [Fact]
+    public async Task Add_AddsTokenToContext()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var token = MakeToken(user.Id, "tok3");
+        var repository = new EfRefreshTokenRepository(db);
+
+        repository.Add(token);
+        await db.SaveChangesAsync(ct);
+
+        var found = await repository.FindByHashAsync("tok3", ct);
+        found.Should().NotBeNull();
+    }
+}

--- a/src/Anichron.Core.Tests.Unit/Data/Repository/UserRepositoryTests.cs
+++ b/src/Anichron.Core.Tests.Unit/Data/Repository/UserRepositoryTests.cs
@@ -237,7 +237,8 @@ public sealed class UserRepositoryTests
         db.Users.Add(user);
         await db.SaveChangesAsync(ct);
         var result = await new EfUserRepository(db).FindByCredentialAsync("alice", ct);
-        result!.Id.Should().Be(user.Id);
+        result.Should().NotBeNull();
+        result.Id.Should().Be(user.Id);
     }
 
     [Fact]
@@ -249,7 +250,8 @@ public sealed class UserRepositoryTests
         db.Users.Add(user);
         await db.SaveChangesAsync(ct);
         var result = await new EfUserRepository(db).FindByCredentialAsync("alice@example.com", ct);
-        result!.Id.Should().Be(user.Id);
+        result.Should().NotBeNull();
+        result.Id.Should().Be(user.Id);
     }
 
     [Fact]
@@ -275,7 +277,8 @@ public sealed class UserRepositoryTests
         db.Users.Add(admin);
         await db.SaveChangesAsync(ct);
         var result = await new EfUserRepository(db).FindAdminByUsernameAsync("admin", ct);
-        result!.Id.Should().Be(admin.Id);
+        result.Should().NotBeNull();
+        result.Id.Should().Be(admin.Id);
     }
 
     [Fact]

--- a/src/Anichron.Core.Tests.Unit/Data/Repository/UserRepositoryTests.cs
+++ b/src/Anichron.Core.Tests.Unit/Data/Repository/UserRepositoryTests.cs
@@ -127,6 +127,230 @@ public sealed class UserRepositoryTests
     }
 
     // ==========================================================================
+    // AnyAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task AnyAsync_NoUsers_ReturnsFalse()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var result = await new EfUserRepository(db).AnyAsync(ct);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AnyAsync_UsersExist_ReturnsTrue()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.Users.Add(MakeUser());
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).AnyAsync(ct);
+        result.Should().BeTrue();
+    }
+
+    // ==========================================================================
+    // AnyByUsernameAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task AnyByUsernameAsync_UsernameExists_ReturnsTrue()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.Users.Add(MakeUser("alice", "alice@example.com"));
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).AnyByUsernameAsync("alice", ct);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AnyByUsernameAsync_UsernameDoesNotExist_ReturnsFalse()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var result = await new EfUserRepository(db).AnyByUsernameAsync("nobody", ct);
+        result.Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // AnyByEmailAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task AnyByEmailAsync_EmailExists_ReturnsTrue()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.Users.Add(MakeUser("alice", "alice@example.com"));
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).AnyByEmailAsync("alice@example.com", ct);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task AnyByEmailAsync_EmailDoesNotExist_ReturnsFalse()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var result = await new EfUserRepository(db).AnyByEmailAsync("nobody@example.com", ct);
+        result.Should().BeFalse();
+    }
+
+    // ==========================================================================
+    // FindByIdAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindByIdAsync_ExistingId_ReturnsUser()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).FindByIdAsync(user.Id, ct);
+        result.Should().NotBeNull();
+        result.Id.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_UnknownId_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var result = await new EfUserRepository(db).FindByIdAsync(Guid.NewGuid(), ct);
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // FindByCredentialAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindByCredentialAsync_ByUsername_ReturnsUser()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser("alice", "alice@example.com");
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).FindByCredentialAsync("alice", ct);
+        result!.Id.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task FindByCredentialAsync_ByEmail_ReturnsUser()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser("alice", "alice@example.com");
+        db.Users.Add(user);
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).FindByCredentialAsync("alice@example.com", ct);
+        result!.Id.Should().Be(user.Id);
+    }
+
+    [Fact]
+    public async Task FindByCredentialAsync_NoMatch_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var result = await new EfUserRepository(db).FindByCredentialAsync("nobody", ct);
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // FindAdminByUsernameAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindAdminByUsernameAsync_AdminExists_ReturnsUser()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var admin = MakeUser("admin", "admin@example.com");
+        admin.IsAdmin = true;
+        db.Users.Add(admin);
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).FindAdminByUsernameAsync("admin", ct);
+        result!.Id.Should().Be(admin.Id);
+    }
+
+    [Fact]
+    public async Task FindAdminByUsernameAsync_NonAdminWithUsername_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        db.Users.Add(MakeUser("alice", "alice@example.com"));
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).FindAdminByUsernameAsync("alice", ct);
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FindAdminByUsernameAsync_NoMatch_ReturnsNull()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var result = await new EfUserRepository(db).FindAdminByUsernameAsync("nobody", ct);
+        result.Should().BeNull();
+    }
+
+    // ==========================================================================
+    // FindAdminsAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task FindAdminsAsync_ReturnsOnlyAdmins()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var admin = MakeUser("admin", "admin@example.com");
+        admin.IsAdmin = true;
+        var regular = MakeUser("alice", "alice@example.com");
+        await db.Users.AddRangeAsync(admin, regular);
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).FindAdminsAsync(10, ct);
+        result.Should().ContainSingle(u => u.Id == admin.Id);
+    }
+
+    [Fact]
+    public async Task FindAdminsAsync_RespectsTakeLimit()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        for (var i = 0; i < 5; i++)
+        {
+            var admin = MakeUser($"admin{i}", $"admin{i}@example.com");
+            admin.IsAdmin = true;
+            db.Users.Add(admin);
+        }
+
+        await db.SaveChangesAsync(ct);
+        var result = await new EfUserRepository(db).FindAdminsAsync(3, ct);
+        result.Should().HaveCount(3);
+    }
+
+    // ==========================================================================
+    // Add
+    // ==========================================================================
+
+    [Fact]
+    public async Task Add_AddsUserToContext()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await using var db = CreateDb();
+        var user = MakeUser();
+        var repository = new EfUserRepository(db);
+        repository.Add(user);
+        await db.SaveChangesAsync(ct);
+        var found = await repository.FindByIdAsync(user.Id, ct);
+        found.Should().NotBeNull();
+    }
+
+    // ==========================================================================
     // Remove
     // ==========================================================================
 

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/ExifDataTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/ExifDataTests.cs
@@ -1,0 +1,21 @@
+using Anichron.Worker.Ingestion;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion;
+
+public sealed class ExifDataTests
+{
+    [Fact]
+    public void Empty_HasAllZeroAndNullFields()
+    {
+        ExifData.Empty.Width.Should().Be(0);
+        ExifData.Empty.Height.Should().Be(0);
+        ExifData.Empty.OrientationDegrees.Should().Be(0);
+        ExifData.Empty.DateCaptured.Should().BeNull();
+        ExifData.Empty.Latitude.Should().BeNull();
+        ExifData.Empty.Longitude.Should().BeNull();
+        ExifData.Empty.CameraMake.Should().BeNull();
+        ExifData.Empty.CameraModel.Should().BeNull();
+        ExifData.Empty.LensModel.Should().BeNull();
+        ExifData.Empty.DurationInSeconds.Should().BeNull();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionContextTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionContextTests.cs
@@ -16,4 +16,17 @@ public sealed class IngestionContextTests
         };
         context.ProxyFiles.Should().NotBeNull().And.BeEmpty();
     }
+
+    [Fact]
+    public void Asset_CanBeSetAndRead()
+    {
+        var context = new IngestionContext
+        {
+            Item = new SingleFileItem("/abs/file.jpg", "file.jpg", MediaType.Image),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        };
+        var asset = new MediaAsset();
+        context.Asset = asset;
+        context.Asset.Should().BeSameAs(asset);
+    }
 }

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionContextTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionContextTests.cs
@@ -1,0 +1,19 @@
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Pipeline;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Pipeline;
+
+public sealed class IngestionContextTests
+{
+    [Fact]
+    public void ProxyFiles_DefaultsToEmptyList()
+    {
+        var context = new IngestionContext
+        {
+            Item = new SingleFileItem("/abs/file.jpg", "file.jpg", MediaType.Image),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        };
+        context.ProxyFiles.Should().NotBeNull().And.BeEmpty();
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
@@ -78,10 +78,9 @@ public sealed class IngestionPipelineBuilderTests
         middleware.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError(string.Empty));
 
         var pipeline = IngestionPipelineBuilder.Build([middleware], Substitute.For<ILogger>());
-        try
-        { await pipeline(MakeContext(), CancellationToken.None); }
-        catch (PipelineConfigurationException exception) { _ = exception; }
+        var act = async () => await pipeline(MakeContext(), CancellationToken.None);
 
+        await act.Should().ThrowAsync<PipelineConfigurationException>();
         await middleware.DidNotReceive().InvokeAsync(
             Arg.Any<IngestionContext>(), Arg.Any<IngestionDelegate>(), Arg.Any<CancellationToken>());
     }
@@ -97,10 +96,9 @@ public sealed class IngestionPipelineBuilderTests
         second.OnCannotInvoke(Arg.Any<IngestionContext>()).Returns(new IngestionStepError(string.Empty));
 
         var pipeline = IngestionPipelineBuilder.Build([first, second], Substitute.For<ILogger>());
-        try
-        { await pipeline(MakeContext(), CancellationToken.None); }
-        catch (PipelineConfigurationException exception) { _ = exception; }
+        var act = async () => await pipeline(MakeContext(), CancellationToken.None);
 
+        await act.Should().ThrowAsync<PipelineConfigurationException>();
         invoked.Should().Contain(1);
     }
 

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/PipelineConfigurationExceptionTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/PipelineConfigurationExceptionTests.cs
@@ -1,0 +1,23 @@
+using Anichron.Worker.Ingestion.Pipeline;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Pipeline;
+
+public sealed class PipelineConfigurationExceptionTests
+{
+    [Fact]
+    public void Parameterless_HasDefaultMessage()
+    {
+        var ex = new PipelineConfigurationException();
+        ex.Message.Should().NotBeNullOrEmpty();
+        ex.InnerException.Should().BeNull();
+    }
+
+    [Fact]
+    public void MessageAndInnerException_BothPreserved()
+    {
+        var inner = new InvalidOperationException("root cause");
+        var ex = new PipelineConfigurationException("oops", inner);
+        ex.Message.Should().Be("oops");
+        ex.InnerException.Should().BeSameAs(inner);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `InviteRepositoryTests` — covers `FindValidByHashAsync` (valid, expired, used, unknown) and `Add`
- Add `RefreshTokenRepositoryTests` — covers `FindByHashWithUserAsync`, `FindByHashAsync`, and `Add`
- Extend `UserRepositoryTests` — comprehensive coverage for all repository methods
- Add `ExifDataTests` — verifies `ExifData.Empty` has all-zero/null fields (extracted from middleware tests where it was misplaced)
- Add `IngestionContextTests` — verifies `ProxyFiles` initialises to an empty list
- Add `PipelineConfigurationExceptionTests` — constructor coverage (extracted from `IngestionPipelineBuilderTests`)
- Fix `IngestionPipelineBuilderTests` — replace two `try/catch` patterns with `Should().ThrowAsync()` + separate mock assertion, consistent with the rest of the file

## Notes

`RevokeAllActiveByUserIdAsync` and `DeleteExpiredAsync` on `EfRefreshTokenRepository` use `ExecuteUpdateAsync`/`ExecuteDeleteAsync` — not supported by the EF InMemory provider. They are covered at the service layer in `TokenCleanupServiceTests`.
