### PR TITLE
fix(ci): switch to HtmlInline report and add .nojekyll for Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           reports: 'coverage/**/coverage.cobertura.xml'
           targetdir: 'coverage/report'
-          reporttypes: 'HtmlInline_AzurePipelines;MarkdownSummaryGithub;Badges'
+          reporttypes: 'HtmlInline;MarkdownSummaryGithub;Badges'
           verbosity: 'Warning'
 
       - name: Publish coverage summary
@@ -74,7 +74,7 @@ jobs:
 
       - name: Prepare coverage report for Pages
         if: github.ref == 'refs/heads/master'
-        run: cp coverage/report/index.htm coverage/report/index.html
+        run: touch coverage/report/.nojekyll
 
       - name: Upload coverage report to Pages
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary

- Switch ReportGenerator type from `HtmlInline_AzurePipelines` to `HtmlInline` — generates `index.html` directly, removing the fragile `cp index.htm index.html` step
- Replace the `cp` step with `touch coverage/report/.nojekyll` — prevents Jekyll from processing the Pages artifact, which was causing GitHub Pages to serve the repository README instead of the coverage report

## Root cause

After Dependabot bumped `actions/upload-pages-artifact` v3→v5 and `actions/deploy-pages` v4→v5, Jekyll processing of the artifact began interfering with the report. Without a `.nojekyll` marker, GitHub Pages fell back to serving the repository README at `https://bitbiter-dev.github.io/anichron/`.

## Test plan

- [ ] `build-and-test` job passes — no reference to `index.htm` anywhere
- [ ] `deploy-pages` job completes successfully on the next master push
- [ ] `https://bitbiter-dev.github.io/anichron/` renders the HTML coverage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)