### PR TITLE
feat(worker): Add image proxy generation middleware

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           reports: 'coverage/**/coverage.cobertura.xml'
           targetdir: 'coverage/report'
-          reporttypes: 'HtmlInline_AzurePipelines;MarkdownSummaryGithub;Badges'
+          reporttypes: 'HtmlInline;MarkdownSummaryGithub;Badges'
           verbosity: 'Warning'
 
       - name: Publish coverage summary
@@ -74,7 +74,7 @@ jobs:
 
       - name: Prepare coverage report for Pages
         if: github.ref == 'refs/heads/master'
-        run: cp coverage/report/index.htm coverage/report/index.html
+        run: touch coverage/report/.nojekyll
 
       - name: Upload coverage report to Pages
         if: github.ref == 'refs/heads/master'

--- a/src/Anichron.API.Tests.Unit/GlobalUsings.cs
+++ b/src/Anichron.API.Tests.Unit/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using Anichron.Core;
 global using FluentAssertions;
 global using NodaTime;
 global using NSubstitute;

--- a/src/Anichron.API.Tests.Unit/Services/AdminStorageConfigServiceTests.cs
+++ b/src/Anichron.API.Tests.Unit/Services/AdminStorageConfigServiceTests.cs
@@ -1,4 +1,3 @@
-using Anichron.API.Security;
 using Anichron.API.Services;
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;

--- a/src/Anichron.API/GlobalUsings.cs
+++ b/src/Anichron.API/GlobalUsings.cs
@@ -1,1 +1,2 @@
+global using Anichron.Core;
 global using NodaTime;

--- a/src/Anichron.API/Services/AdminStorageConfigService.cs
+++ b/src/Anichron.API/Services/AdminStorageConfigService.cs
@@ -1,4 +1,3 @@
-using Anichron.API.Security;
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Core.Domain;

--- a/src/Anichron.Core/GuidFactory.cs
+++ b/src/Anichron.Core/GuidFactory.cs
@@ -1,4 +1,4 @@
-namespace Anichron.API.Security;
+namespace Anichron.Core;
 
 public interface IGuidFactory
 {

--- a/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Crawling/FileIngestionPipelineTests.cs
@@ -1,3 +1,4 @@
+using Anichron.Core;
 using Anichron.Core.Domain;
 using Anichron.Worker.Crawling;
 using Anichron.Worker.Ingestion;
@@ -65,6 +66,7 @@ public sealed class FileIngestionPipelineTests
                 FileSystem,
                 new LivePhotoLinker(FileSystem),
                 options,
+                Substitute.For<IGuidFactory>(),
                 Substitute.For<ILogger<FileIngestionPipeline>>());
         }
     }

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ContentHashingMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ContentHashingMiddlewareTests.cs
@@ -12,6 +12,7 @@ public sealed class ContentHashingMiddlewareTests
     {
         Item = new SingleFileItem(path, "photo.jpg", MediaType.Image),
         Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        AssetId = Guid.NewGuid(),
     };
 
     // ==========================================================================
@@ -65,11 +66,13 @@ public sealed class ContentHashingMiddlewareTests
         {
             Item = new SingleFileItem("/abs/a.jpg", "a.jpg", MediaType.Image),
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
         };
         var contextB = new IngestionContext
         {
             Item = new SingleFileItem("/abs/b.jpg", "b.jpg", MediaType.Image),
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
         };
 
         await new ContentHashingMiddleware(fs).InvokeAsync(contextA, (_, _) => Task.CompletedTask, CancellationToken.None);
@@ -90,11 +93,13 @@ public sealed class ContentHashingMiddlewareTests
         {
             Item = new SingleFileItem("/abs/a.jpg", "a.jpg", MediaType.Image),
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
         };
         var contextB = new IngestionContext
         {
             Item = new SingleFileItem("/abs/b.jpg", "b.jpg", MediaType.Image),
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
         };
 
         await new ContentHashingMiddleware(fs).InvokeAsync(contextA, (_, _) => Task.CompletedTask, CancellationToken.None);
@@ -115,6 +120,7 @@ public sealed class ContentHashingMiddlewareTests
         {
             Item = new LivePhotoPairItem("/abs/photo.heic", "photo.heic", "/abs/photo.mov", "photo.mov"),
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
         };
 
         await new ContentHashingMiddleware(fs).InvokeAsync(context, (_, _) => Task.CompletedTask, CancellationToken.None);

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ExifExtractionMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ExifExtractionMiddlewareTests.cs
@@ -30,6 +30,7 @@ public sealed class ExifExtractionMiddlewareTests
     {
         Item = new SingleFileItem(path, "photo.jpg", MediaType.Image),
         Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        AssetId = Guid.NewGuid(),
         ContentHash = contentHash,
     };
 

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/IdempotencyCheckMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/IdempotencyCheckMiddlewareTests.cs
@@ -21,6 +21,7 @@ public sealed class IdempotencyCheckMiddlewareTests
     {
         Item = new SingleFileItem("/abs/photo.jpg", "photo.jpg", MediaType.Image),
         Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        AssetId = Guid.NewGuid(),
         ContentHash = contentHash,
     };
 

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ImageProxyMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ImageProxyMiddlewareTests.cs
@@ -223,4 +223,48 @@ public sealed class ImageProxyMiddlewareTests
         await fx.ImageProcessor.DidNotReceive()
             .CreateThumbnailAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task InvokeAsync_LivePhotoPairItem_GeneratesProxyFilesAsync()
+    {
+        var fx = new TestFixture();
+        fx.FileSystem.AddFile("/nas/photo.heic", new MockFileData([0xFF, 0xD8, 0xFF, 0xD9]));
+        var context = new IngestionContext
+        {
+            Item = new LivePhotoPairItem("/nas/photo.heic", "photo.heic", "/nas/photo.mov", "photo.mov"),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/nas" },
+            AssetId = Guid.NewGuid(),
+        };
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_SetsCorrectSizeBytesOnEachProxyFileAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        // Thumbnail [0x01,0x02] = 2 B; Preview [0x03,0x04] = 2 B; Blurhash = 28-char ASCII string = 28 B
+        context.ProxyFiles.Single(p => p.ProxyType == ProxyType.Thumbnail).SizeBytes.Should().Be(2);
+        context.ProxyFiles.Single(p => p.ProxyType == ProxyType.FullPreview).SizeBytes.Should().Be(2);
+        context.ProxyFiles.Single(p => p.ProxyType == ProxyType.BlurHash).SizeBytes.Should().Be(28);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_AssignsProxyFileIdsFromGuidFactoryAsync()
+    {
+        var fx = new TestFixture();
+        var expectedId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+        fx.GuidFactory.NewGuid().Returns(expectedId);
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().AllSatisfy(p => p.Id.Should().Be(expectedId));
+    }
 }

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ImageProxyMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/ImageProxyMiddlewareTests.cs
@@ -1,0 +1,226 @@
+using Anichron.Core;
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion;
+using Anichron.Worker.Ingestion.Middlewares;
+using Anichron.Worker.Ingestion.Pipeline;
+using Anichron.Worker.Ingestion.Proxy;
+using Anichron.Worker.Settings;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using System.IO.Abstractions.TestingHelpers;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Middlewares;
+
+public sealed class ImageProxyMiddlewareTests
+{
+    private sealed class TestFixture
+    {
+        public IImageProcessor ImageProcessor { get; } = Substitute.For<IImageProcessor>();
+        public MockFileSystem FileSystem { get; } = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            ["/nas/photo.jpg"] = new MockFileData([0xFF, 0xD8, 0xFF, 0xD9]),
+        });
+        public Instant Now { get; } = Instant.FromUtc(2026, 5, 19, 10, 0, 0);
+
+        public TestFixture()
+        {
+            var clock = Substitute.For<IClock>();
+            clock.GetCurrentInstant().Returns(Now);
+            Clock = clock;
+
+            ImageProcessor.CreateThumbnailAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .Returns([0x01, 0x02]);
+            ImageProcessor.CreateFullPreviewAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .Returns([0x03, 0x04]);
+            ImageProcessor.ComputeBlurhashAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+                .Returns("LGFFaXYk^6#M@-5c,1J5@[or[Q6.");
+        }
+
+        public IClock Clock { get; }
+        public IGuidFactory GuidFactory { get; } = Substitute.For<IGuidFactory>();
+
+        public ImageProxyMiddleware Build()
+        {
+            IImageProxyGenerator[] generators =
+            [
+                new ThumbnailGenerator(ImageProcessor),
+                new FullPreviewGenerator(ImageProcessor),
+                new BlurhashGenerator(ImageProcessor),
+            ];
+            return new(generators,
+                       new TwoLevelHexShardStrategy(),
+                       Options.Create(new WorkerSettings { ProxyPath = "/proxies" }),
+                       FileSystem,
+                       Clock,
+                       GuidFactory,
+                       Substitute.For<ILogger<ImageProxyMiddleware>>());
+        }
+    }
+
+    private static IngestionContext MakeContext(MediaType mediaType = MediaType.Image)
+        => new()
+        {
+            Item = new SingleFileItem("/nas/photo.jpg", "photo.jpg", mediaType),
+            Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/nas" },
+            AssetId = Guid.NewGuid(),
+        };
+
+    private static Task NoOpNextAsync(IngestionContext ctx, CancellationToken ct)
+    {
+        _ = (ctx, ct);
+        return Task.CompletedTask;
+    }
+
+    // ==========================================================================
+    // InvokeAsync
+    // ==========================================================================
+
+    [Fact]
+    public async Task InvokeAsync_Always_CallsNextAsync()
+    {
+        var fx = new TestFixture();
+        var nextCalled = false;
+        Task NextAsync(IngestionContext ctx, CancellationToken ct)
+        {
+            _ = (ctx, ct);
+            nextCalled = true;
+            return Task.CompletedTask;
+        }
+
+        await fx.Build().InvokeAsync(MakeContext(), NextAsync, CancellationToken.None);
+
+        nextCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_AddsThreeProxyFilesToContextAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_AddsThumbnailProxyAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().ContainSingle(p => p.ProxyType == ProxyType.Thumbnail);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_AddsFullPreviewProxyAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().ContainSingle(p => p.ProxyType == ProxyType.FullPreview);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_AddsBlurhashProxyAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().ContainSingle(p => p.ProxyType == ProxyType.BlurHash);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_ProxyPathsContainAssetShardAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        var expectedShard = context.AssetId.ToString("N")[..2];
+        context.ProxyFiles.Should().AllSatisfy(p => p.ProxyPath.Should().StartWith(expectedShard));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_ProxyFilesHaveContextAssetIdAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().AllSatisfy(p => p.AssetId.Should().Be(context.AssetId));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_ProxyFilesHaveCreatedAtFromClockAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().AllSatisfy(p => p.CreatedAt.Should().Be(fx.Now));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_WritesThumbnailFileToDiskAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        var shard = context.AssetId.ToString("N");
+        fx.FileSystem.FileExists($"/proxies/{shard[..2]}/{shard[2..]}/thumbnail.jpg")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_WritesPreviewFileToDiskAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        var shard = context.AssetId.ToString("N");
+        fx.FileSystem.FileExists($"/proxies/{shard[..2]}/{shard[2..]}/preview.jpg")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ImageItem_WritesBlurhashFileToDiskAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext();
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        var shard = context.AssetId.ToString("N");
+        fx.FileSystem.FileExists($"/proxies/{shard[..2]}/{shard[2..]}/blurhash.txt")
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_VideoItem_SkipsProxyGenerationAndCallsNextAsync()
+    {
+        var fx = new TestFixture();
+        var context = MakeContext(MediaType.Video);
+        fx.FileSystem.AddFile("/nas/photo.jpg", new MockFileData([0xFF, 0xD8]));
+
+        await fx.Build().InvokeAsync(context, NoOpNextAsync, CancellationToken.None);
+
+        context.ProxyFiles.Should().BeEmpty();
+        await fx.ImageProcessor.DidNotReceive()
+            .CreateThumbnailAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/LoggingMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/LoggingMiddlewareTests.cs
@@ -12,6 +12,7 @@ public sealed class LoggingMiddlewareTests
     {
         Item = new SingleFileItem(absolutePath, "photo.jpg", MediaType.Image),
         Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        AssetId = Guid.NewGuid(),
     };
 
     // ==========================================================================

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/PersistenceMiddlewareTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Middlewares/PersistenceMiddlewareTests.cs
@@ -1,3 +1,4 @@
+using Anichron.Core;
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Core.Domain;
@@ -36,8 +37,10 @@ public sealed class PersistenceMiddlewareTests
 
         public IClock Clock { get; }
 
+        public IGuidFactory GuidFactory { get; } = Substitute.For<IGuidFactory>();
+
         public PersistenceMiddleware Build()
-            => new(Repository, UnitOfWork, FileSystem, Clock, Substitute.For<ILogger<PersistenceMiddleware>>());
+            => new(Repository, UnitOfWork, FileSystem, Clock, GuidFactory, Substitute.For<ILogger<PersistenceMiddleware>>());
     }
 
     private static readonly ExifData DefaultExif =
@@ -53,6 +56,7 @@ public sealed class PersistenceMiddlewareTests
         {
             Item = resolvedItem,
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
             ContentHash = contentHash,
             SecondaryHash = resolvedItem.SecondaryFile is not null ? "cafebabe" : null,
             Exif = exif ?? DefaultExif,

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionContextTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionContextTests.cs
@@ -13,6 +13,7 @@ public sealed class IngestionContextTests
         {
             Item = new SingleFileItem("/abs/file.jpg", "file.jpg", MediaType.Image),
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
         };
         context.ProxyFiles.Should().NotBeNull().And.BeEmpty();
     }
@@ -24,6 +25,7 @@ public sealed class IngestionContextTests
         {
             Item = new SingleFileItem("/abs/file.jpg", "file.jpg", MediaType.Image),
             Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+            AssetId = Guid.NewGuid(),
         };
         var asset = new MediaAsset();
         context.Asset = asset;

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineBuilderTests.cs
@@ -11,6 +11,7 @@ public sealed class IngestionPipelineBuilderTests
     {
         Item = new SingleFileItem("/abs/file.jpg", "file.jpg", MediaType.Image),
         Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        AssetId = Guid.NewGuid(),
     };
 
     // ==========================================================================

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineRunnerTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Pipeline/IngestionPipelineRunnerTests.cs
@@ -11,6 +11,7 @@ public sealed class IngestionPipelineRunnerTests
     {
         Item = new SingleFileItem("/abs/file.jpg", "file.jpg", MediaType.Image),
         Config = new UserStorageConfig { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), RootPath = "/abs" },
+        AssetId = Guid.NewGuid(),
     };
 
     // ==========================================================================

--- a/src/Anichron.Worker.Tests.Unit/Ingestion/Proxy/ImageProxyGeneratorsTests.cs
+++ b/src/Anichron.Worker.Tests.Unit/Ingestion/Proxy/ImageProxyGeneratorsTests.cs
@@ -1,0 +1,46 @@
+using Anichron.Worker.Ingestion.Proxy;
+
+namespace Anichron.Worker.Tests.Unit.Ingestion.Proxy;
+
+public sealed class ImageProxyGeneratorsTests
+{
+    // ==========================================================================
+    // TwoLevelHexShardStrategy
+    // ==========================================================================
+
+    [Fact]
+    public void GetDirectory_ProducesCorrectTwoLevelPath()
+    {
+        var id = Guid.Parse("abcdef12-3456-7890-abcd-ef1234567890");
+
+        var result = new TwoLevelHexShardStrategy().GetDirectory(id);
+
+        result.Should().Be("ab/cdef1234567890abcdef1234567890");
+    }
+
+    [Fact]
+    public void GetDirectory_TopDirectoryIsAlwaysTwoChars()
+    {
+        var id = Guid.Parse("00000000-0000-0000-0000-000000000001");
+
+        var top = new TwoLevelHexShardStrategy().GetDirectory(id).Split('/')[0];
+
+        top.Should().HaveLength(2);
+    }
+
+    // ==========================================================================
+    // BlurhashGenerator
+    // ==========================================================================
+
+    [Fact]
+    public async Task GenerateAsync_ReturnsUtf8EncodedHashBytesAsync()
+    {
+        var processor = Substitute.For<IImageProcessor>();
+        processor.ComputeBlurhashAsync(Arg.Any<Stream>(), Arg.Any<CancellationToken>())
+            .Returns("HASH");
+
+        var bytes = await new BlurhashGenerator(processor).GenerateAsync(Stream.Null, CancellationToken.None);
+
+        bytes.Should().Equal("HASH"u8.ToArray());
+    }
+}

--- a/src/Anichron.Worker/Anichron.Worker.csproj
+++ b/src/Anichron.Worker/Anichron.Worker.csproj
@@ -13,7 +13,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Blurhash.ImageSharp" />
     <PackageReference Include="MetadataExtractor" />
+    <PackageReference Include="SixLabors.ImageSharp" />
     <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="System.IO.Abstractions" />
   </ItemGroup>

--- a/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
+++ b/src/Anichron.Worker/Crawling/FileIngestionPipeline.cs
@@ -1,3 +1,4 @@
+using Anichron.Core;
 using Anichron.Core.Domain;
 using Anichron.Worker.Ingestion;
 using Anichron.Worker.Ingestion.Pipeline;
@@ -18,6 +19,7 @@ internal sealed partial class FileIngestionPipeline(
     IFileSystem fileSystem,
     ILivePhotoLinker livePhotoLinker,
     IOptions<WorkerSettings> workerOptions,
+    IGuidFactory guidFactory,
     ILogger<FileIngestionPipeline> logger) : IFileIngestionPipeline
 {
     private readonly WorkerSettings settings = workerOptions.Value;
@@ -104,7 +106,7 @@ internal sealed partial class FileIngestionPipeline(
             var runner = diScope.ServiceProvider.GetRequiredService<IIngestionPipelineRunner>();
             try
             {
-                var context = new IngestionContext { Item = item, Config = config };
+                var context = new IngestionContext { Item = item, Config = config, AssetId = guidFactory.NewGuid() };
                 await runner.RunAsync(context, ct);
             }
             catch (Exception ex)

--- a/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
+++ b/src/Anichron.Worker/Infrastructure/HostApplicationBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using Anichron.Core;
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Infrastructure.Configuration;
@@ -29,6 +30,11 @@ public static class HostApplicationBuilderExtensions
                 new IniEntry("Worker", "MaxConcurrentFiles", () => "4"),
                 new IniEntry("Worker", "TokenCleanupIntervalHours", () => "24"),
                 new IniEntry("Worker", "ProxyPath", () => "/data/proxies"),
+                new IniEntry("Worker", "ThumbnailMaxWidth", () => "300"),
+                new IniEntry("Worker", "ThumbnailJpegQuality", () => "75"),
+                new IniEntry("Worker", "PreviewMaxWidth", () => "1920"),
+                new IniEntry("Worker", "PreviewJpegQuality", () => "85"),
+                new IniEntry("Worker", "BlurhashSampleWidth", () => "64"),
             ]);
             builder.Configuration.AddIniFile(iniPath, optional: false, reloadOnChange: false);
             builder.Configuration.AddEnvironmentVariables();
@@ -48,6 +54,7 @@ public static class HostApplicationBuilderExtensions
         public HostApplicationBuilder AddWorkerCoreServices()
         {
             builder.Services.Configure<WorkerSettings>(builder.Configuration.GetSection("Worker"));
+            builder.Services.AddSingleton<IGuidFactory, TimeOrderedGuidFactory>();
             builder.Services.AddSingleton<IClock>(SystemClock.Instance);
             builder.Services.AddSingleton<WorkerState>();
             return builder;

--- a/src/Anichron.Worker/Ingestion/Middlewares/ImageProxyMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/ImageProxyMiddleware.cs
@@ -1,0 +1,80 @@
+using Anichron.Core;
+using Anichron.Core.Domain;
+using Anichron.Worker.Ingestion.Pipeline;
+using Anichron.Worker.Ingestion.Proxy;
+using Anichron.Worker.Settings;
+using Microsoft.Extensions.Options;
+using NodaTime;
+using System.IO.Abstractions;
+
+namespace Anichron.Worker.Ingestion.Middlewares;
+
+internal sealed partial class ImageProxyMiddleware(
+    IEnumerable<IImageProxyGenerator> generators,
+    IProxyDirectoryStrategy proxyDirectoryStrategy,
+    IOptions<WorkerSettings> settings,
+    IFileSystem fileSystem,
+    IClock clock,
+    IGuidFactory guidFactory,
+    ILogger<ImageProxyMiddleware> logger) : IIngestionMiddleware
+{
+    private readonly HashSet<string> createdDirectories = [];
+
+    public int Order => IngestionOrder.ImageProxy;
+
+    public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
+    {
+        // Video thumbnails require FFmpeg frame extraction — handled by a future VideoProxyMiddleware.
+        if (context.Item.PrimaryMediaType == MediaType.Video)
+        {
+            await next(context, ct);
+            return;
+        }
+
+        var proxyRoot = settings.Value.ProxyPath;
+        var proxyDirectoryName = proxyDirectoryStrategy.GetDirectory(context.AssetId);
+        var proxyPath = Path.Combine(proxyRoot, proxyDirectoryName);
+        var sourceBytes = await fileSystem.File.ReadAllBytesAsync(context.Item.AbsolutePath, ct);
+
+        if (createdDirectories.Add(proxyPath))
+            fileSystem.Directory.CreateDirectory(proxyPath);
+
+        var proxyFiles = await Task.WhenAll(generators.Select(WriteProxyAsync));
+
+        context.ProxyFiles.AddRange(proxyFiles);
+
+        Log.ProxiesGenerated(logger, proxyFiles.Length, context.Item.RelativePath);
+        await next(context, ct);
+        return;
+
+        async Task<ProxyFile> WriteProxyAsync(IImageProxyGenerator generator)
+        {
+            var relativePath = $"{proxyDirectoryName}/{generator.FileName}";
+            await using var ms = new MemoryStream(sourceBytes);
+            var bytes = await generator.GenerateAsync(ms, ct);
+            await fileSystem.File.WriteAllBytesAsync(Path.Combine(proxyRoot, relativePath), bytes, ct);
+            Log.ProxyWritten(logger, generator.ProxyType, bytes.Length, context.Item.RelativePath);
+            return BuildProxyFile(context, relativePath, generator.ProxyType, bytes.Length);
+        }
+    }
+
+    private ProxyFile BuildProxyFile(IngestionContext context, string relPath, ProxyType type, long sizeBytes)
+        => new()
+        {
+            Id = guidFactory.NewGuid(),
+            AssetId = context.AssetId,
+            ProxyPath = relPath,
+            ProxyType = type,
+            SizeBytes = sizeBytes,
+            CreatedAt = clock.GetCurrentInstant(),
+        };
+
+    private static partial class Log
+    {
+        [LoggerMessage(Level = LogLevel.Debug, Message = "Wrote {ProxyType} proxy ({SizeBytes} B) for {RelativePath}.")]
+        public static partial void ProxyWritten(ILogger logger, ProxyType proxyType, int sizeBytes, string relativePath);
+
+        [LoggerMessage(Level = LogLevel.Information, Message = "Generated {Count} proxy files for {RelativePath}.")]
+        public static partial void ProxiesGenerated(ILogger logger, int count, string relativePath);
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Middlewares/ImageProxyMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/ImageProxyMiddleware.cs
@@ -18,8 +18,6 @@ internal sealed partial class ImageProxyMiddleware(
     IGuidFactory guidFactory,
     ILogger<ImageProxyMiddleware> logger) : IIngestionMiddleware
 {
-    private readonly HashSet<string> createdDirectories = [];
-
     public int Order => IngestionOrder.ImageProxy;
 
     public async Task InvokeAsync(IngestionContext context, IngestionDelegate next, CancellationToken ct)
@@ -36,8 +34,7 @@ internal sealed partial class ImageProxyMiddleware(
         var proxyPath = Path.Combine(proxyRoot, proxyDirectoryName);
         var sourceBytes = await fileSystem.File.ReadAllBytesAsync(context.Item.AbsolutePath, ct);
 
-        if (createdDirectories.Add(proxyPath))
-            fileSystem.Directory.CreateDirectory(proxyPath);
+        fileSystem.Directory.CreateDirectory(proxyPath);
 
         var proxyFiles = await Task.WhenAll(generators.Select(WriteProxyAsync));
 

--- a/src/Anichron.Worker/Ingestion/Middlewares/PersistenceMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Middlewares/PersistenceMiddleware.cs
@@ -1,3 +1,4 @@
+using Anichron.Core;
 using Anichron.Core.Data;
 using Anichron.Core.Data.Repository;
 using Anichron.Core.Domain;
@@ -12,6 +13,7 @@ internal sealed partial class PersistenceMiddleware(
     IUnitOfWork unitOfWork,
     IFileSystem fileSystem,
     IClock clock,
+    IGuidFactory guidFactory,
     ILogger<PersistenceMiddleware> logger) : IIngestionMiddleware
 {
     public int Order => IngestionOrder.Persistence;
@@ -44,7 +46,7 @@ internal sealed partial class PersistenceMiddleware(
 
         return new MediaAsset
         {
-            Id = Guid.NewGuid(),
+            Id = context.AssetId,
             StorageConfigId = context.Config.Id,
             FilePath = relativePath,
             FileName = Path.GetFileName(relativePath),
@@ -79,7 +81,7 @@ internal sealed partial class PersistenceMiddleware(
 
         return new MediaAsset
         {
-            Id = Guid.NewGuid(),
+            Id = guidFactory.NewGuid(),
             StorageConfigId = context.Config.Id,
             FilePath = secondary.RelativePath,
             FileName = Path.GetFileName(secondary.RelativePath),

--- a/src/Anichron.Worker/Ingestion/Pipeline/IIngestionMiddleware.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IIngestionMiddleware.cs
@@ -15,5 +15,6 @@ internal static class IngestionOrder
     public const int ContentHashing = 10;
     public const int IdempotencyCheck = 20;
     public const int ExifExtraction = 30;
-    public const int Persistence = 40;
+    public const int ImageProxy = 40;
+    public const int Persistence = 50;
 }

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionContext.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionContext.cs
@@ -7,6 +7,8 @@ internal sealed class IngestionContext
     public required IngestionItem Item { get; init; }
     public required UserStorageConfig Config { get; init; }
 
+    public required Guid AssetId { get; init; }
+
     public string? ContentHash { get; set; }
     public string? SecondaryHash { get; set; }
     public ExifData? Exif { get; set; }

--- a/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
+++ b/src/Anichron.Worker/Ingestion/Pipeline/IngestionServiceCollectionExtensions.cs
@@ -1,17 +1,33 @@
 using Anichron.Worker.Ingestion.Middlewares;
+using Anichron.Worker.Ingestion.Proxy;
 
 namespace Anichron.Worker.Ingestion.Pipeline;
 
 internal static class IngestionServiceCollectionExtensions
 {
-    internal static IServiceCollection AddIngestionSteps(this IServiceCollection services)
+    extension(IServiceCollection services)
     {
-        services.AddScoped<IIngestionMiddleware, LoggingMiddleware>();
-        services.AddScoped<IIngestionMiddleware, ContentHashingMiddleware>();
-        services.AddScoped<IIngestionMiddleware, IdempotencyCheckMiddleware>();
-        services.AddScoped<IIngestionMiddleware, ExifExtractionMiddleware>();
-        services.AddScoped<IIngestionMiddleware, PersistenceMiddleware>();
-        services.AddScoped<IIngestionPipelineRunner, IngestionPipelineRunner>();
-        return services;
+        internal IServiceCollection AddIngestionSteps()
+        {
+            services.AddImageProxyServices();
+            services.AddScoped<IIngestionMiddleware, LoggingMiddleware>();
+            services.AddScoped<IIngestionMiddleware, ContentHashingMiddleware>();
+            services.AddScoped<IIngestionMiddleware, IdempotencyCheckMiddleware>();
+            services.AddScoped<IIngestionMiddleware, ExifExtractionMiddleware>();
+            services.AddScoped<IIngestionMiddleware, ImageProxyMiddleware>();
+            services.AddScoped<IIngestionMiddleware, PersistenceMiddleware>();
+            services.AddScoped<IIngestionPipelineRunner, IngestionPipelineRunner>();
+            return services;
+        }
+
+        private IServiceCollection AddImageProxyServices()
+        {
+            services.AddSingleton<IImageProcessor, ImageSharpProcessor>();
+            services.AddSingleton<IProxyDirectoryStrategy, TwoLevelHexShardStrategy>();
+            services.AddSingleton<IImageProxyGenerator, ThumbnailGenerator>();
+            services.AddSingleton<IImageProxyGenerator, FullPreviewGenerator>();
+            services.AddSingleton<IImageProxyGenerator, BlurhashGenerator>();
+            return services;
+        }
     }
 }

--- a/src/Anichron.Worker/Ingestion/Proxy/ImageProcessor.cs
+++ b/src/Anichron.Worker/Ingestion/Proxy/ImageProcessor.cs
@@ -17,34 +17,36 @@ internal interface IImageProcessor
 
 internal sealed class ImageSharpProcessor(IOptions<WorkerSettings> options) : IImageProcessor
 {
+    private readonly WorkerSettings settings = options.Value;
+
     public async Task<byte[]> CreateThumbnailAsync(Stream source, CancellationToken ct)
     {
         using var image = await Image.LoadAsync(source, ct);
         image.Mutate(x => x.Resize(new ResizeOptions
         {
-            Size = new Size(options.Value.ThumbnailMaxWidth, 0),
+            Size = new Size(settings.ThumbnailMaxWidth, 0),
             Mode = ResizeMode.Max,
         }));
 
         await using var ms = new MemoryStream();
-        await image.SaveAsJpegAsync(ms, new JpegEncoder { Quality = options.Value.ThumbnailJpegQuality }, ct);
+        await image.SaveAsJpegAsync(ms, new JpegEncoder { Quality = settings.ThumbnailJpegQuality }, ct);
         return ms.ToArray();
     }
 
     public async Task<byte[]> CreateFullPreviewAsync(Stream source, CancellationToken ct)
     {
         using var image = await Image.LoadAsync(source, ct);
-        if (image.Width > options.Value.PreviewMaxWidth)
+        if (image.Width > settings.PreviewMaxWidth)
         {
             image.Mutate(x => x.Resize(new ResizeOptions
             {
-                Size = new Size(options.Value.PreviewMaxWidth, 0),
+                Size = new Size(settings.PreviewMaxWidth, 0),
                 Mode = ResizeMode.Max,
             }));
         }
 
         await using var ms = new MemoryStream();
-        await image.SaveAsJpegAsync(ms, new JpegEncoder { Quality = options.Value.PreviewJpegQuality }, ct);
+        await image.SaveAsJpegAsync(ms, new JpegEncoder { Quality = settings.PreviewJpegQuality }, ct);
         return ms.ToArray();
     }
 
@@ -53,7 +55,7 @@ internal sealed class ImageSharpProcessor(IOptions<WorkerSettings> options) : II
         using var image = await Image.LoadAsync<Rgba32>(source, ct);
         image.Mutate(x => x.Resize(new ResizeOptions
         {
-            Size = new Size(options.Value.BlurhashSampleWidth, 0),
+            Size = new Size(settings.BlurhashSampleWidth, 0),
             Mode = ResizeMode.Max,
         }));
 

--- a/src/Anichron.Worker/Ingestion/Proxy/ImageProcessor.cs
+++ b/src/Anichron.Worker/Ingestion/Proxy/ImageProcessor.cs
@@ -1,0 +1,62 @@
+using Anichron.Worker.Settings;
+using Blurhash.ImageSharp;
+using Microsoft.Extensions.Options;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+
+namespace Anichron.Worker.Ingestion.Proxy;
+
+internal interface IImageProcessor
+{
+    Task<byte[]> CreateThumbnailAsync(Stream source, CancellationToken ct);
+    Task<byte[]> CreateFullPreviewAsync(Stream source, CancellationToken ct);
+    Task<string> ComputeBlurhashAsync(Stream source, CancellationToken ct);
+}
+
+internal sealed class ImageSharpProcessor(IOptions<WorkerSettings> options) : IImageProcessor
+{
+    public async Task<byte[]> CreateThumbnailAsync(Stream source, CancellationToken ct)
+    {
+        using var image = await Image.LoadAsync(source, ct);
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Size = new Size(options.Value.ThumbnailMaxWidth, 0),
+            Mode = ResizeMode.Max,
+        }));
+
+        await using var ms = new MemoryStream();
+        await image.SaveAsJpegAsync(ms, new JpegEncoder { Quality = options.Value.ThumbnailJpegQuality }, ct);
+        return ms.ToArray();
+    }
+
+    public async Task<byte[]> CreateFullPreviewAsync(Stream source, CancellationToken ct)
+    {
+        using var image = await Image.LoadAsync(source, ct);
+        if (image.Width > options.Value.PreviewMaxWidth)
+        {
+            image.Mutate(x => x.Resize(new ResizeOptions
+            {
+                Size = new Size(options.Value.PreviewMaxWidth, 0),
+                Mode = ResizeMode.Max,
+            }));
+        }
+
+        await using var ms = new MemoryStream();
+        await image.SaveAsJpegAsync(ms, new JpegEncoder { Quality = options.Value.PreviewJpegQuality }, ct);
+        return ms.ToArray();
+    }
+
+    public async Task<string> ComputeBlurhashAsync(Stream source, CancellationToken ct)
+    {
+        using var image = await Image.LoadAsync<Rgba32>(source, ct);
+        image.Mutate(x => x.Resize(new ResizeOptions
+        {
+            Size = new Size(options.Value.BlurhashSampleWidth, 0),
+            Mode = ResizeMode.Max,
+        }));
+
+        return Blurhasher.Encode(image, 4, 3);
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Proxy/ImageProxyGenerators.cs
+++ b/src/Anichron.Worker/Ingestion/Proxy/ImageProxyGenerators.cs
@@ -1,0 +1,38 @@
+using Anichron.Core.Domain;
+using System.Text;
+
+namespace Anichron.Worker.Ingestion.Proxy;
+
+internal interface IImageProxyGenerator
+{
+    string FileName { get; }
+    ProxyType ProxyType { get; }
+    Task<byte[]> GenerateAsync(Stream source, CancellationToken ct);
+}
+
+internal sealed class ThumbnailGenerator(IImageProcessor imageProcessor) : IImageProxyGenerator
+{
+    public string FileName => "thumbnail.jpg";
+    public ProxyType ProxyType => ProxyType.Thumbnail;
+    public Task<byte[]> GenerateAsync(Stream source, CancellationToken ct)
+        => imageProcessor.CreateThumbnailAsync(source, ct);
+}
+
+internal sealed class FullPreviewGenerator(IImageProcessor imageProcessor) : IImageProxyGenerator
+{
+    public string FileName => "preview.jpg";
+    public ProxyType ProxyType => ProxyType.FullPreview;
+    public Task<byte[]> GenerateAsync(Stream source, CancellationToken ct)
+        => imageProcessor.CreateFullPreviewAsync(source, ct);
+}
+
+internal sealed class BlurhashGenerator(IImageProcessor imageProcessor) : IImageProxyGenerator
+{
+    public string FileName => "blurhash.txt";
+    public ProxyType ProxyType => ProxyType.BlurHash;
+    public async Task<byte[]> GenerateAsync(Stream source, CancellationToken ct)
+    {
+        var hash = await imageProcessor.ComputeBlurhashAsync(source, ct);
+        return Encoding.UTF8.GetBytes(hash);
+    }
+}

--- a/src/Anichron.Worker/Ingestion/Proxy/ProxyShardStrategy.cs
+++ b/src/Anichron.Worker/Ingestion/Proxy/ProxyShardStrategy.cs
@@ -7,7 +7,7 @@ internal interface IProxyDirectoryStrategy
 
 internal sealed class TwoLevelHexShardStrategy : IProxyDirectoryStrategy
 {
-    // Produces {first 2 hex chars}/{remaining 30 hex chars} — caps the top-level bucket count at 256.
+    // Two hex chars → 256 top-level buckets; prevents filesystem directory-count blowup at large library sizes.
     public string GetDirectory(Guid assetId)
     {
         var hex = assetId.ToString("N");

--- a/src/Anichron.Worker/Ingestion/Proxy/ProxyShardStrategy.cs
+++ b/src/Anichron.Worker/Ingestion/Proxy/ProxyShardStrategy.cs
@@ -1,0 +1,16 @@
+namespace Anichron.Worker.Ingestion.Proxy;
+
+internal interface IProxyDirectoryStrategy
+{
+    string GetDirectory(Guid assetId);
+}
+
+internal sealed class TwoLevelHexShardStrategy : IProxyDirectoryStrategy
+{
+    // Produces {first 2 hex chars}/{remaining 30 hex chars} — caps the top-level bucket count at 256.
+    public string GetDirectory(Guid assetId)
+    {
+        var hex = assetId.ToString("N");
+        return $"{hex[..2]}/{hex[2..]}";
+    }
+}

--- a/src/Anichron.Worker/Settings/WorkerSettings.cs
+++ b/src/Anichron.Worker/Settings/WorkerSettings.cs
@@ -13,4 +13,14 @@ public sealed record WorkerSettings
     public double TokenCleanupIntervalHours { get; init; } = 24;
 
     public string ProxyPath { get; init; } = "/data/proxies";
+
+    public int ThumbnailMaxWidth { get; init; } = 300;
+
+    public int ThumbnailJpegQuality { get; init; } = 75;
+
+    public int PreviewMaxWidth { get; init; } = 1920;
+
+    public int PreviewJpegQuality { get; init; } = 85;
+
+    public int BlurhashSampleWidth { get; init; } = 64;
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="Production dependencies">
+    <PackageVersion Include="Blurhash.ImageSharp" Version="3.0.0" />
     <PackageVersion Include="Konscious.Security.Cryptography.Argon2" Version="1.3.1" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageVersion Include="MetadataExtractor" Version="2.8.1" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.0" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.1.1" />


### PR DESCRIPTION
## Summary

- Adds `ImageProxyMiddleware` that generates thumbnail, full preview, and blurhash proxies for every ingested image, writing them to the configured proxy path under a two-level hex shard directory (`{id[0:2]}/{id[2:]}`)
- Introduces `IImageProxyGenerator` / `IImageProcessor` / `IProxyDirectoryStrategy` abstractions backed by ImageSharp and Blurhash.ImageSharp
- Makes all 5 image-processing constants (`ThumbnailMaxWidth`, `ThumbnailJpegQuality`, `PreviewMaxWidth`, `PreviewJpegQuality`, `BlurhashSampleWidth`) configurable via `WorkerSettings` + INI entries
- Moves `IGuidFactory` / `TimeOrderedGuidFactory` from `Anichron.API.Security` to `Anichron.Core` so both the API and Worker share the same factory
- Makes `IngestionContext.AssetId` a `required init` property populated by `IGuidFactory` in `FileIngestionPipeline`, ensuring any future change to GUID generation propagates automatically
- Refactors `AddIngestionSteps` to delegate image-proxy DI registrations to a private `AddImageProxyServices` helper

## Test plan

- [x] `dotnet build src/` — 0 warnings, 0 errors
- [x] `dotnet test src/` — all 522 tests pass
- [x] `dotnet format --verify-no-changes src/` — no formatting violations
- [ ] `ImageProxyMiddlewareTests` — 13 tests covering proxy file count, proxy types, shard paths, file writes to disk, size bytes, GUID factory usage, video skip, and live photo pair
- [ ] `ImageProxyGeneratorsTests` — shard path format and blurhash UTF-8 encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)